### PR TITLE
First draft of config spec

### DIFF
--- a/config-spec.md
+++ b/config-spec.md
@@ -27,7 +27,7 @@ Open Truss uses nested composable configurations to define everything in the sys
   - Their **Name** is required.
 - **Global ID**.
   - Everything in Open Truss is automatically assigned a global identifier.
-  - An Open Truss Global ID is a valid URL path.
+  - An Open Truss Global ID is a valid URI path.
 
 ## Sample configuration
 

--- a/config-spec.md
+++ b/config-spec.md
@@ -1,26 +1,30 @@
 Open Truss uses nested composable configurations to define everything in the system. This allows for its users to share and build on each other's work and for the community to help create reusable configurations.
 
 ## Key concepts
-- **Workflow**.
+- **Frame**.
   - A grouping of pieces of configuration. It has all of the information necessary to be usable on its own.
-  - Workflows can specify a **Query**.
+  - Frames can specify:
     - (optional) **Name**.
     - (optional) **Description**.
-    - (optional) **Query**.
-      - A specification for how to retrieve data for a workflow.
+    - (optional) **Data**.
+      - A specification for how to retrieve data for a Frame.
       - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).
-      - A workflow can only have a single query.
+      - A Frame can only have a single data configuration.
     - (optional) **Layout**.
       - Spec for `layout` is to be determined, but could probably start with some sort of Flexbox configuration.
-  - Additionally, Workflows can specify a component to render _or_ nested workflows:
-    - **Component**.
-      - A React component to render for this workflow.
-      - Components are automatically given their workflow's query's results, if any.
+  - Additionally, Frames can specify a view to render _or_ nested frames:
+    - **View**.
+      - A React component to render for this frame.
+      - Components are automatically given their frame's query's results, if any.
       - Components may also have additional configuration, through a field called `props`.
-    - **Workflows**.
-      - A workflow can have other workflows nested underneath it.
-      - For example, a workflow could define a webpage that has many workflows on it.
-      - Because of this, some workflows will have no query nor components; they will only define a collection of workflows.
+    - **Frames**.
+      - A frame can have other frames nested underneath it.
+      - For example, a frame could define a webpage that has many frames on it.
+      - Because of this, some frames will have no query nor components; they will only define a collection of frames.
+- **Workflow**.
+  - A 'top level' collection of Frames.
+  - These are the main collections of Frames that are used in the system.
+  - Their **Name** is required.
 - **Global ID**.
   - Everything in Open Truss is automatically assigned a global identifier.
   - An Open Truss Global ID is a valid URL path.
@@ -29,43 +33,36 @@ Open Truss uses nested composable configurations to define everything in the sys
 
 ```md
 ---
-# This top-level workflow has no query or components itself. Instead, it only
-# defines the name and description and then renders additional workflows underneath it.
-name: Accounts created on 2023-10-16
-description: Renders PageTitle, DataTable, and TotalCount components.
-layout: TBD
+workflow:
+  name: Accounts created on 2023-10-16
+  description: Renders PageTitle, DataTable, and TotalCount components.
+  layout: TBD
 
-workflows:
-  # This workflow has no query. Its PageTitle component has its props set in the configuration.
-  - name: First Workflow
-    component:
-      component: PageTitle
-      props:
-        title: Accounts created on 2023-10-16
-
-  # This workflow will execute a query and render its results in a DataTable
-  # component and summarize those same results in a TotalCount component.
-  - name: Second Workflow
-    query:
-      query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
-      type: MYSQL
-      datasource: &some_reference_to_datasource_configs_or_client
-    workflows:
-      - component:
-          component: DataTable
-          # Props are defined by components. In this case `columnConfiguration` is an object
-          # whose keys map to column headers from the query and defines how to render a
-          # specialized component for each row's value for that column.
+  frames:
+    # This frame has no query. Its PageTitle component has its props set in the configuration.
+    - frame:
+        view:
+          component: PageTitle
           props:
-            columnConfiguration:
-              account_id:
-                component: Link
-                props:
-                  url_format: "/accounts/:account_id"
-                  hotkey: "g a"
+            title: Accounts created on 2023-10-16
 
-      - component:
-          component: TotalCount
-          # Components each get the query's results automatically.
-          # TotalCount doesn't need any additional configuration, so we pass nothing in.
+    # This frame will execute a query and render its results in a DataTable
+    # component and summarize those same results in a TotalCount component.
+    - frame:
+        data:
+          query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
+          type: MYSQL
+          source: &some_reference_to_datasource_configs_or_client
+        frames:
+          - frame:
+              view:
+                component: DataTable
+                props:
+                  style:
+                    color: red
+          - frame:
+              view:
+                component: TotalCount
+                # Components each get the query's results automatically.
+                # TotalCount doesn't need any additional configuration, so we pass nothing in.
 ```

--- a/config-spec.md
+++ b/config-spec.md
@@ -1,0 +1,62 @@
+Open Truss uses nested composible configurations to define everything in the system. This allows for its users to share and build on each other's work and for the community to help create reusable configurations.
+
+## Key concepts
+- **Workflow**.
+  - A grouping of pieces of configuration. It has all of the information necessary to be usable on its own.
+  - Workflows have a name and optionally a description.
+  - Workflows also consist of the follow additional key concepts:
+    - **Query**.
+      - A specification for how to retrieve data for a workflow.
+      - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).
+      - A workflow can only have a single query. ???
+    - **Components**.
+      - A list of React components to render for this workflow.
+      - Each component is automatically given its workflow's query's results.
+      - Components may also have additional configuration, through a field called `props`.
+    - **Workflows**.
+      - A workflow can have other workflows nested underneath it.
+      - For example, a workflow could define a webpage that has many workflows on it.
+      - Because of this, some workflows will have no query nor components; they will only define a collection of workflows.
+- **Global ID**.
+  - Everything in Open Truss is automatically assigned a global identifier.
+  - An Open Truss Global ID is a valid URL path.
+
+## Sample configuration
+
+```md
+---
+# This top-level workflow has no query or components itself. Instead, it only
+# defines the name and description and then renders additional workflows underneath it.
+name: Accounts created on 2023-10-16
+description: Renders PageTitle, DataTable, and TotalCount components.
+
+workflows:
+  # This workflow has no query. Its PageTitle component has its props set in the configuration.
+  - components:
+      - component: PageTitle
+        props:
+          title: Accounts created on 2023-10-16
+
+  # This workflow will execute a query and render its results in a DataTable
+  # component and summarize those same results in a TotalCount component.
+  - query:
+      query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
+      type: MYSQL
+      host: some-server
+    components:
+      - component: DataTable
+          # Props are defined by components. In this case `columnConfiguration` is an object
+          # whose keys map to column headers from the query and defines how to render a
+          # specialized component for each row's value for that column.
+          props:
+            columnConfiguration:
+              account_id:
+                component: Link
+                props:
+                  url_format: "/accounts/:account_id"
+                  hotkey: "g a"
+
+      - component: TotalCount
+          # Components each get the query's results automatically.
+          # TotalCount doesn't need any additional configuration, so we pass nothing in.
+```

--- a/config-spec.md
+++ b/config-spec.md
@@ -41,27 +41,27 @@ workflow:
   frames:
     # This frame has no query. Its PageTitle component has its props set in the configuration.
     - frame:
-        view:
-          component: PageTitle
-          props:
-            title: Accounts created on 2023-10-16
+      view:
+        component: PageTitle
+        props:
+          title: Accounts created on 2023-10-16
 
     # This frame will execute a query and render its results in a DataTable
     # component and summarize those same results in a TotalCount component.
     - frame:
-        data:
-          query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
-          type: MYSQL
-          source: &some_reference_to_datasource_configs_or_client
-        frames:
-          - frame:
-              view:
-                component: DataTable
-                props:
-                  showTooltips: false
-          - frame:
-              view:
-                component: TotalCount
-                # Components each get the query's results automatically.
-                # TotalCount doesn't need any additional configuration, so we pass nothing in.
+      data:
+        query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
+        type: MYSQL
+        source: &some_reference_to_datasource_configs_or_client
+      frames:
+        - frame:
+          view:
+            component: DataTable
+            props:
+              showTooltips: false
+        - frame:
+          view:
+            component: TotalCount
+            # Components each get the query's results automatically.
+            # TotalCount doesn't need any additional configuration, so we pass nothing in.
 ```

--- a/config-spec.md
+++ b/config-spec.md
@@ -58,8 +58,7 @@ workflow:
               view:
                 component: DataTable
                 props:
-                  style:
-                    color: red
+                  showTooltips: false
           - frame:
               view:
                 component: TotalCount

--- a/config-spec.md
+++ b/config-spec.md
@@ -49,7 +49,7 @@ workflows:
     query:
       query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
       type: MYSQL
-      host: some-server
+      datasource: &some_reference_to_datasource_configs_or_client
     workflows:
       - component:
           component: DataTable

--- a/config-spec.md
+++ b/config-spec.md
@@ -8,7 +8,7 @@ Open Truss uses nested composible configurations to define everything in the sys
     - **Query**.
       - A specification for how to retrieve data for a workflow.
       - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).
-      - A workflow can only have a single query. ???
+      - A workflow can only have a single query.
     - **Components**.
       - A list of React components to render for this workflow.
       - Each component is automatically given its workflow's query's results.

--- a/config-spec.md
+++ b/config-spec.md
@@ -1,17 +1,18 @@
-Open Truss uses nested composible configurations to define everything in the system. This allows for its users to share and build on each other's work and for the community to help create reusable configurations.
+Open Truss uses nested composable configurations to define everything in the system. This allows for its users to share and build on each other's work and for the community to help create reusable configurations.
 
 ## Key concepts
 - **Workflow**.
   - A grouping of pieces of configuration. It has all of the information necessary to be usable on its own.
-  - Workflows have a name and optionally a description.
-  - Workflows also include some combination of the following:
+  - Workflows have optional names and descriptions.
+  - Workflows can specify a **Query**.
     - **Query**.
       - A specification for how to retrieve data for a workflow.
       - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).
       - A workflow can only have a single query.
-    - **Components**.
-      - A list of React components to render for this workflow.
-      - Each component is automatically given its workflow's query's results.
+  - Workflows can either specify a component to render or nested workflows:
+    - **Component**.
+      - A React component to render for this workflow.
+      - Components are automatically given their workflow's query's results, if any.
       - Components may also have additional configuration, through a field called `props`.
     - **Workflows**.
       - A workflow can have other workflows nested underneath it.
@@ -32,19 +33,22 @@ description: Renders PageTitle, DataTable, and TotalCount components.
 
 workflows:
   # This workflow has no query. Its PageTitle component has its props set in the configuration.
-  - components:
-      - component: PageTitle
-        props:
-          title: Accounts created on 2023-10-16
+  - name: First Workflow
+    component:
+      component: PageTitle
+      props:
+        title: Accounts created on 2023-10-16
 
   # This workflow will execute a query and render its results in a DataTable
   # component and summarize those same results in a TotalCount component.
-  - query:
+  - name: Second Workflow
+    query:
       query: select account_id, account_login from accounts where date(created_at) = '2023-10-16' order by id desc;
       type: MYSQL
       host: some-server
-    components:
-      - component: DataTable
+    workflows:
+      - component:
+          component: DataTable
           # Props are defined by components. In this case `columnConfiguration` is an object
           # whose keys map to column headers from the query and defines how to render a
           # specialized component for each row's value for that column.
@@ -56,7 +60,8 @@ workflows:
                   url_format: "/accounts/:account_id"
                   hotkey: "g a"
 
-      - component: TotalCount
+      - component:
+          component: TotalCount
           # Components each get the query's results automatically.
           # TotalCount doesn't need any additional configuration, so we pass nothing in.
 ```

--- a/config-spec.md
+++ b/config-spec.md
@@ -4,7 +4,7 @@ Open Truss uses nested composible configurations to define everything in the sys
 - **Workflow**.
   - A grouping of pieces of configuration. It has all of the information necessary to be usable on its own.
   - Workflows have a name and optionally a description.
-  - Workflows also consist of the follow additional key concepts:
+  - Workflows also include some combination of the following:
     - **Query**.
       - A specification for how to retrieve data for a workflow.
       - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).

--- a/config-spec.md
+++ b/config-spec.md
@@ -3,13 +3,16 @@ Open Truss uses nested composable configurations to define everything in the sys
 ## Key concepts
 - **Workflow**.
   - A grouping of pieces of configuration. It has all of the information necessary to be usable on its own.
-  - Workflows have optional names and descriptions.
   - Workflows can specify a **Query**.
-    - **Query**.
+    - (optional) **Name**.
+    - (optional) **Description**.
+    - (optional) **Query**.
       - A specification for how to retrieve data for a workflow.
       - Queries must specify their `type` (e.g. MYSQL, GRAPHQL, REST) and `source` (the URL or configured host to use).
       - A workflow can only have a single query.
-  - Workflows can either specify a component to render or nested workflows:
+    - (optional) **Layout**.
+      - Spec for `layout` is to be determined, but could probably start with some sort of Flexbox configuration.
+  - Additionally, Workflows can specify a component to render _or_ nested workflows:
     - **Component**.
       - A React component to render for this workflow.
       - Components are automatically given their workflow's query's results, if any.
@@ -30,6 +33,7 @@ Open Truss uses nested composable configurations to define everything in the sys
 # defines the name and description and then renders additional workflows underneath it.
 name: Accounts created on 2023-10-16
 description: Renders PageTitle, DataTable, and TotalCount components.
+layout: TBD
 
 workflows:
   # This workflow has no query. Its PageTitle component has its props set in the configuration.


### PR DESCRIPTION
## Why?

Everything in Open Truss is powered by configurations. Starting to iterate on what the configuration specification is early on could help us prototype features.

## How?

I started a `config-spec.md` document in the root of this repo. In it I define a few key concept and then illustrate them with a sample configuration.

[Here it is rendered](https://github.com/open-truss/open-truss/blob/config-spec-v0/config-spec.md).

In my opinion, stuff like this is really difficult to read typically. If folks have examples of projects that have significant configuration that document its use well, I'd love to see them so we can build off a good example.

## What's not in here
- I said that everything has an ID but didn't expand on that at all.
- I have thoughts about query reuse that I'll post in a comment on this PR so we can discuss a bit.
