### PR TITLE
Publish package on every merge for now

### DIFF
--- a/packages/open-truss/.github/workflows/publish-package.yml
+++ b/packages/open-truss/.github/workflows/publish-package.yml
@@ -1,0 +1,20 @@
+name: Publish Package to npmjs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: cd packages/open-truss
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why

We should set up a process for the open-truss npm pacakge

## How

For now while we are still scaffolding the app and not too worried about breaking changes, I setup an action that publishes everytime a push to main happens (in other words a PR is merged). Eventually we probably want to revisit this process and have something more methodical like linking publishes to GitHub releases. i.e. everything we make a new release we can automatically publish the package.

## Considerations

Alternative options are:
- Move forward with the release approach and publish packages everything a release is made. This felt a little too heavy handed in these early days
- Have people manually publish to npm from their local env. This is probably fine, but having some automation reduce the friction here felt nice.

@open-truss/engineers 