### PR TITLE
Fix package publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Publish Package to npmjs
 on:
   push:
     branches:
-      - fix-package-publishing
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Publish Package to npmjs
 on:
   push:
     branches:
-      - main
+      - fix-package-publishing
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +14,7 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
       - run: cd packages/open-truss
+      - run: ls -al
       - run: npm ci
       - run: npm publish --access public
         env:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Publish Package to npmjs
 on:
   push:
     branches:
-      - fix-package-publishing
+      - main
 permissions:
   actions: 'write'
 jobs:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,13 +13,14 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Run CI
+      - name: Change directory
         working-directory: ./packages/open-truss
         run: ls -al
+      - name: Run CI
         run: npm ci
       - name: Publish Package
         working-directory: ./packages/open-truss
         run: ls -al
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # run: npm publish --access public
+        # env:
+        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,22 +15,10 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Skip if package.json version unchanged
-        run: |
-          if git diff ${{ github.event.before }} ${{ github.sha }} -- packages/open-truss/package.json | grep "[[:space:]][[:space:]]\"version"; then
-              echo "package.json version changed. Continuting with package publishing"
-          else
-              echo "package.json version has not changed. Skipping package publishing"
-              gh run cancel ${{ github.run_id }}
-              gh run watch ${{ github.run_id }}
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run CI
         working-directory: ./packages/open-truss
         run: npm ci
-      - name: Publish Package
-        working-directory: ./packages/open-truss
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: ./packages/open-truss

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,14 +13,11 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Change directory
-        working-directory: ./packages/open-truss
-        run: ls -al
       - name: Run CI
+        working-directory: ./packages/open-truss
         run: npm ci
       - name: Publish Package
         working-directory: ./packages/open-truss
-        run: ls -al
-        # run: npm publish --access public
-        # env:
-        #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - fix-package-publishing
+permissions:
+  actions: 'write'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,8 +21,11 @@ jobs:
               echo "package.json version changed. Continuting with package publishing"
           else
               echo "package.json version has not changed. Skipping package publishing"
-              exit 0
+              gh run cancel ${{ github.run_id }}
+              gh run watch ${{ github.run_id }}
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run CI
         working-directory: ./packages/open-truss
         run: npm ci

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -15,13 +15,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Skip if package.json version unchanged
         run: |
-          pr_version=$(git show ${{ github.event.before }}:packages/open-truss/package.json | jq -r .version)
-          main_version=$(git show ${{ github.sha }}:packages/open-truss/package.json | jq -r .version)
-          if [ "$pr_version" = "$main_version" ]; then
+          if git diff ${{ github.event.before }} ${{ github.sha }} -- packages/open-truss/package.json | grep "[[:space:]][[:space:]]\"version"; then
+              echo "package.json version changed. Continuting with package publishing"
+          else
               echo "package.json version has not changed. Skipping package publishing"
               exit 0
-          else
-              echo "package.json version changed. Continuting with package publishing"
           fi
       - name: Run CI
         working-directory: ./packages/open-truss

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,7 +2,7 @@ name: Publish Package to npmjs
 on:
   push:
     branches:
-      - main
+      - fix-package-publishing
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +13,16 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
+      - name: Skip if package.json version unchanged
+        run: |
+          pr_version=$(git show ${{ github.event.before }}:packages/open-truss/package.json | jq -r .version)
+          main_version=$(git show ${{ github.sha }}:packages/open-truss/package.json | jq -r .version)
+          if [ "$pr_version" = "$main_version" ]; then
+              echo "package.json version has not changed. Skipping package publishing"
+              exit 0
+          else
+              echo "package.json version changed. Continuting with package publishing"
+          fi
       - name: Run CI
         working-directory: ./packages/open-truss
         run: npm ci

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-permissions:
-  actions: 'write'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,9 +13,13 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: cd packages/open-truss
-      - run: ls -al
-      - run: npm ci
-      - run: npm publish --access public
+      - name: Run CI
+        working-directory: ./packages/open-truss
+        run: ls -al
+        run: npm ci
+      - name: Publish Package
+        working-directory: ./packages/open-truss
+        run: ls -al
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
Fixes the script that publishes a new package every time a PR merges. Can see the package successfully publish in this actions run https://github.com/open-truss/open-truss/actions/runs/6738603968/job/18318529441

One quirk that I'm not realizing is that we'll need to bump the package version on every PR. A couple thoughts:
- We could add a CI step that fails the build if the PR has a package version lower than what is on main. That will remind us to bump the version.
- If bumping the package version every time we open a PR sounds tedious, perhaps we should abandon this approach altogether. We can disable this actions job and rely on publishing packages manually for now. Eventually when this is in a stable version we can trigger publishes when we open releases in GitHub.

@open-truss/engineers which approach do you all prefer?