### PR TITLE
Prettier!

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -17,7 +17,7 @@ jobs:
         run: npm ci --ignore-scripts
       - name: Run linter
         working-directory: ./packages/open-truss
-        run: npm run lint
+        run: npm run lint:ci
   test:
     runs-on: ubuntu-latest
     steps:

--- a/packages/open-truss/.eslintrc.js
+++ b/packages/open-truss/.eslintrc.js
@@ -1,36 +1,30 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es2021": true,
-        "node": true
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+  ],
+  overrides: [
+    {
+      env: {
+        node: true,
+      },
+      files: ['.eslintrc.{js,cjs}'],
+      parserOptions: {
+        sourceType: 'script',
+      },
     },
-    "extends": [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-        "plugin:react/recommended"
-    ],
-    "overrides": [
-        {
-            "env": {
-                "node": true
-            },
-            "files": [
-                ".eslintrc.{js,cjs}"
-            ],
-            "parserOptions": {
-                "sourceType": "script"
-            }
-        }
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "@typescript-eslint",
-        "react"
-    ],
-    "rules": {
-    }
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'react'],
+  rules: {},
 }

--- a/packages/open-truss/.prettierrc.json
+++ b/packages/open-truss/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/packages/open-truss/.prettierrc.json
+++ b/packages/open-truss/.prettierrc.json
@@ -1,7 +1,7 @@
 {
   "printWidth": 80,
   "tabWidth": 2,
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "trailingComma": "all",
   "bracketSpacing": true,

--- a/packages/open-truss/jest.config.js
+++ b/packages/open-truss/jest.config.js
@@ -2,4 +2,4 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-};
+}

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.0.7",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "sql-formatter": "^13.0.4",
@@ -19,6 +19,7 @@
         "@typescript-eslint/parser": "^6.9.1",
         "eslint": "^8.52.0",
         "eslint-plugin-react": "^7.33.2",
+        "prettier": "^3.0.3",
         "ts-jest": "^29.1.1",
         "typescript": "^5.2.2"
       }
@@ -5314,6 +5315,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -10510,6 +10526,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true
     },
     "pretty-format": {

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -12,10 +12,10 @@
     "build:esm": "tsc --project tsconfig.esm.json",
     "test": "jest",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier --write \"./**/*.{ts,js,json}\" --log-level error",
+    "lint:prettier": "prettier \"./**/*.{ts,js,json}\" --write --log-level error",
     "lint:eslint": "eslint --fix",
     "lint:ci": "npm run lint:prettier:ci && npm run lint:eslint:ci",
-    "lint:prettier:ci": "prettier \"./**/*.{ts,js,json}\" --log-level error",
+    "lint:prettier:ci": "prettier \"./**/*.{ts,js,json}\" --check",
     "lint:eslint:ci": "eslint",
     "tsc:watch": "tsc --watch --project tsconfig.json"
   },

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -11,7 +11,9 @@
     "build": "tsc --project tsconfig.json",
     "build:esm": "tsc --project tsconfig.esm.json",
     "test": "jest",
-    "lint": "eslint",
+    "lint": "npm run lint:prettier && npm run lint:eslint",
+    "lint:prettier": "prettier --write \"./**/*.{ts,js,json},!package-lock.json,!node_modules\" --loglevel error",
+    "lint:eslint": "eslint",
     "tsc:watch": "tsc --watch --project tsconfig.json"
   },
   "files": [
@@ -51,6 +53,7 @@
     "@typescript-eslint/parser": "^6.9.1",
     "eslint": "^8.52.0",
     "eslint-plugin-react": "^7.33.2",
+    "prettier": "^3.0.3",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   }

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -13,7 +13,10 @@
     "test": "jest",
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier --write \"./**/*.{ts,js,json}\" --log-level error",
-    "lint:eslint": "eslint",
+    "lint:eslint": "eslint --fix",
+    "lint:ci": "npm run lint:prettier:ci && npm run lint:eslint:ci",
+    "lint:prettier:ci": "prettier \"./**/*.{ts,js,json}\" --log-level error",
+    "lint:eslint:ci": "eslint",
     "tsc:watch": "tsc --watch --project tsconfig.json"
   },
   "files": [

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -12,7 +12,7 @@
     "build:esm": "tsc --project tsconfig.esm.json",
     "test": "jest",
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier --write \"./**/*.{ts,js,json},!package-lock.json,!node_modules\" --loglevel error",
+    "lint:prettier": "prettier --write \"./**/*.{ts,js,json}\" --log-level error",
     "lint:eslint": "eslint",
     "tsc:watch": "tsc --watch --project tsconfig.json"
   },

--- a/packages/open-truss/src/hello_world/index.ts
+++ b/packages/open-truss/src/hello_world/index.ts
@@ -1,5 +1,5 @@
 function helloWorld() {
-  return "Hello, World!"
+  return 'Hello, World!'
 }
 
 export default helloWorld

--- a/packages/open-truss/src/utils/format.test.ts
+++ b/packages/open-truss/src/utils/format.test.ts
@@ -2,10 +2,9 @@ import { formatQuery } from './format'
 
 describe('formatQuery', () => {
   it('injects named number values', () => {
-    const actual = formatQuery(
-      'SELECT * FROM users WHERE id = :id',
-      { params: { id: 12345 } },
-    )
+    const actual = formatQuery('SELECT * FROM users WHERE id = :id', {
+      params: { id: 12345 },
+    })
     const expected = `
 SELECT
     *
@@ -18,10 +17,9 @@ WHERE
   })
 
   it('injects named string values', () => {
-    const actual = formatQuery(
-      'SELECT * FROM users WHERE login = :login',
-      { params: { login: 'foobar' } },
-    )
+    const actual = formatQuery('SELECT * FROM users WHERE login = :login', {
+      params: { login: 'foobar' },
+    })
     const expected = `
 SELECT
     *
@@ -34,10 +32,9 @@ WHERE
   })
 
   it('injects named array number values', () => {
-    const actual = formatQuery(
-      'SELECT * FROM users WHERE id IN (:ids)',
-      { params: { ids: [12345, 23456, 67890] } },
-    )
+    const actual = formatQuery('SELECT * FROM users WHERE id IN (:ids)', {
+      params: { ids: [12345, 23456, 67890] },
+    })
     const expected = `
 SELECT
     *
@@ -50,10 +47,9 @@ WHERE
   })
 
   it('injects named array string values', () => {
-    const actual = formatQuery(
-      'SELECT * FROM users WHERE login IN (:logins)', 
-      { params: { logins: ['foo', 'bar', 'baz'] } },
-    )
+    const actual = formatQuery('SELECT * FROM users WHERE login IN (:logins)', {
+      params: { logins: ['foo', 'bar', 'baz'] },
+    })
     const expected = `
 SELECT
     *

--- a/packages/open-truss/src/utils/format.ts
+++ b/packages/open-truss/src/utils/format.ts
@@ -3,14 +3,14 @@ import { format as sqlFormat, SqlLanguage } from 'sql-formatter'
 export type Param = string | number | string[] | number[]
 
 export interface Config {
-  language?: SqlLanguage,
-  params?: Record<string, Param>,
+  language?: SqlLanguage
+  params?: Record<string, Param>
 }
 
 function formatParam(param: Param): string {
   if (typeof param === 'number') {
     return String(param)
-  }else if (typeof param === 'string') {
+  } else if (typeof param === 'string') {
     return `'${param.replaceAll("'", "''")}'`
   } else if (Array.isArray(param)) {
     return param.map(formatParam).join(',')
@@ -20,9 +20,10 @@ function formatParam(param: Param): string {
 }
 
 function formatParams(params: Record<string, Param>): Record<string, string> {
-  const formattedEntries = Object.entries(params).map(
-    ([key, param]) => [key, formatParam(param)]
-  )
+  const formattedEntries = Object.entries(params).map(([key, param]) => [
+    key,
+    formatParam(param),
+  ])
   return Object.fromEntries(formattedEntries)
 }
 

--- a/packages/open-truss/src/utils/yaml.test.ts
+++ b/packages/open-truss/src/utils/yaml.test.ts
@@ -5,10 +5,12 @@ test('stringifyYaml', () => {
   expect(stringifyYaml('hello')).toBe('hello\n')
   expect(stringifyYaml(true)).toBe('true\n')
   expect(stringifyYaml(null)).toBe('null\n')
-  expect(stringifyYaml({ foo: "bar" })).toBe('foo: bar\n')
-  expect(stringifyYaml([{ foo: "bar" }])).toBe('- foo: bar\n')
+  expect(stringifyYaml({ foo: 'bar' })).toBe('foo: bar\n')
+  expect(stringifyYaml([{ foo: 'bar' }])).toBe('- foo: bar\n')
   expect(stringifyYaml([{ foo: { baz: 4 } }])).toBe('- foo:\n    baz: 4\n')
-  expect(stringifyYaml([{ foo: [4, 2, 1] }])).toBe('- foo:\n    - 4\n    - 2\n    - 1\n')
+  expect(stringifyYaml([{ foo: [4, 2, 1] }])).toBe(
+    '- foo:\n    - 4\n    - 2\n    - 1\n',
+  )
   expect(stringifyYaml([{ foo: [{ baz: 4 }] }])).toBe('- foo:\n    - baz: 4\n')
 })
 
@@ -17,9 +19,11 @@ test('parseYaml', () => {
   expect(parseYaml('hello')).toBe('hello')
   expect(parseYaml('true')).toBe(true)
   expect(parseYaml('null')).toBe(null)
-  expect(parseYaml('foo: bar')).toEqual({ foo: "bar" })
-  expect(parseYaml('- foo: bar')).toEqual([{ foo: "bar" }])
+  expect(parseYaml('foo: bar')).toEqual({ foo: 'bar' })
+  expect(parseYaml('- foo: bar')).toEqual([{ foo: 'bar' }])
   expect(parseYaml('- foo:\n    baz: 4')).toEqual([{ foo: { baz: 4 } }])
-  expect(parseYaml('- foo:\n    - 4\n    - 2\n    - 1')).toEqual([{ foo: [4, 2, 1] }])
+  expect(parseYaml('- foo:\n    - 4\n    - 2\n    - 1')).toEqual([
+    { foo: [4, 2, 1] },
+  ])
   expect(parseYaml('- foo:\n    - baz: 4')).toEqual([{ foo: [{ baz: 4 }] }])
 })


### PR DESCRIPTION
Adding Prettier for code formatting as discussed in https://github.com/open-truss/open-truss/pull/27#issuecomment-1802749552.

Most editors have prettier plugins that will automagically format your code on save. It's an incredible experience! You can also run `npm run lint` and Prettier will format all the project's files for you.

In the CI, if files don't match the Prettier/eslint spec, errors/warnings will be printed instead of the files being automagically fixed.

Most of the changes in the PR are diffs from Prettier formatting. The files I added/changed to setup Prettier itself are:
- `packages/open-truss/package.json`
- `packages/open-truss/.prettierrc.json`
- `.github/workflows/ci-checks.yml`
- `packages/open-truss/package-lock.json`

**Note:** If we aren't sure about using Prettier or don't want to merge this PR, that's okay. This didn't take long to setup. Figured it be easier to actually show what using Prettier looks like rather than try to describe it 😄 