### PR TITLE
Tweak linting rules and apply fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/packages/open-truss/lib/*
+/packages/open-truss/lib-esm/*

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,9 @@ module.exports = {
     },
   },
   plugins: ['react'],
-  rules: {},
+  rules: {
+    '@typescript-eslint/comma-dangle': 'off',
+    '@typescript-eslint/space-before-function-paren': 'off',
+    'react/react-in-jsx-scope': 'off',
+  },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
   plugins: ['react'],
   rules: {
     '@typescript-eslint/comma-dangle': 'off',
+    '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/space-before-function-paren': 'off',
     'react/react-in-jsx-scope': 'off',
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
     '@typescript-eslint/comma-dangle': 'off',
     '@typescript-eslint/return-await': 'off',
     '@typescript-eslint/space-before-function-paren': 'off',
+    '@typescript-eslint/strict-boolean-expressions': 'off',
+    '@typescript-eslint/prefer-nullish-coalescing': 'off',
     'react/react-in-jsx-scope': 'off',
   },
 }

--- a/demo-app/src/app/layout.tsx
+++ b/demo-app/src/app/layout.tsx
@@ -5,11 +5,7 @@ export const metadata: Metadata = {
   description: 'Open Truss demo application.',
 }
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }): JSX.Element {
   return (
     <html lang="en">
       <body>{children}</body>

--- a/demo-app/src/app/page.tsx
+++ b/demo-app/src/app/page.tsx
@@ -1,6 +1,6 @@
-import AvailableWorkflows from "@/components/AvailableWorkflows";
+import AvailableWorkflows from '@/components/AvailableWorkflows'
 
-export default function Home() {
+export default function Home(): JSX.Element {
   return (
     <AvailableWorkflows />
   )

--- a/demo-app/src/app/workflows/[id]/Workflow.tsx
+++ b/demo-app/src/app/workflows/[id]/Workflow.tsx
@@ -6,8 +6,8 @@ function Workflow({ workflow }: { workflow: WorkflowConfiguration }): JSX.Elemen
   // We use `!workflow.component` because we have a contract that workflows either
   // have `workflows` or `component` defined. This trick tells Typescript that
   // `workflow.component` is defined, which we use to our advantage below.
-  if (workflow.component == null) {
-    const workflows = workflow.workflows ?? []
+  if (!workflow.component) {
+    const workflows = workflow.workflows || []
     return (
       <>
         {workflows.map((workflow, i) => <Workflow key={i} workflow={workflow} />)}
@@ -17,10 +17,10 @@ function Workflow({ workflow }: { workflow: WorkflowConfiguration }): JSX.Elemen
 
   const { component: componentConfiguration } = workflow
   const { component, props: propsConfiguration } = componentConfiguration
-  const props = propsConfiguration ?? {}
+  const props = propsConfiguration || {}
 
   // Render this workflow's component
-  const Component = displayComponents[component] ?? component
+  const Component = displayComponents[component] || component
   return <Component {...props} />
 }
 

--- a/demo-app/src/app/workflows/[id]/Workflow.tsx
+++ b/demo-app/src/app/workflows/[id]/Workflow.tsx
@@ -1,13 +1,13 @@
-import { OpenTrussComponentProps, WorkflowConfiguration } from '@/types'
+import type { WorkflowConfiguration } from '@/types'
 import displayComponents from '@/display-components'
 
-function Workflow({ workflow }: { workflow: WorkflowConfiguration }) {
+function Workflow({ workflow }: { workflow: WorkflowConfiguration }): JSX.Element {
   // If there are any nested workflows, render them recursively.
   // We use `!workflow.component` because we have a contract that workflows either
   // have `workflows` or `component` defined. This trick tells Typescript that
   // `workflow.component` is defined, which we use to our advantage below.
-  if (!workflow.component) {
-    const workflows = workflow.workflows || []
+  if (workflow.component == null) {
+    const workflows = workflow.workflows ?? []
     return (
       <>
         {workflows.map((workflow, i) => <Workflow key={i} workflow={workflow} />)}
@@ -17,10 +17,10 @@ function Workflow({ workflow }: { workflow: WorkflowConfiguration }) {
 
   const { component: componentConfiguration } = workflow
   const { component, props: propsConfiguration } = componentConfiguration
-  const props = propsConfiguration || {} as OpenTrussComponentProps
+  const props = propsConfiguration ?? {}
 
   // Render this workflow's component
-  const Component = displayComponents[component] || component
+  const Component = displayComponents[component] ?? component
   return <Component {...props} />
 }
 

--- a/demo-app/src/app/workflows/[id]/page.tsx
+++ b/demo-app/src/app/workflows/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs'
 import * as yaml from 'yaml'
-import { WorkflowConfiguration } from '@/types'
+import type { WorkflowConfiguration } from '@/types'
 import Workflow from './Workflow'
 
 // TODO this should be cached since what's on disk can't change
@@ -9,7 +9,7 @@ async function loadWorkflowFromDisk(workflowId: string): Promise<WorkflowConfigu
   return yaml.parse(fileContents)
 }
 
-async function WorkflowPage({ params }: { params: { id: string }}) {
+async function WorkflowPage({ params }: { params: { id: string } }): Promise<JSX.Element> {
   const workflow = await loadWorkflowFromDisk(params.id)
 
   return <Workflow workflow={workflow} />

--- a/demo-app/src/components/AvailableWorkflows.tsx
+++ b/demo-app/src/components/AvailableWorkflows.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 // TODO this should be cached since what's on disk can't change
 async function availableWorkflowsFromDisk(): Promise<string[]> {
-  return await fs.readdir('./src/workflows/')
+  return fs.readdir('./src/workflows/')
 }
 
 async function AvailableWorkflows(): Promise<JSX.Element> {

--- a/demo-app/src/components/AvailableWorkflows.tsx
+++ b/demo-app/src/components/AvailableWorkflows.tsx
@@ -2,11 +2,11 @@ import { promises as fs } from 'fs'
 import Link from 'next/link'
 
 // TODO this should be cached since what's on disk can't change
-function availableWorkflowsFromDisk() {
-  return fs.readdir('./src/workflows/')
+async function availableWorkflowsFromDisk(): Promise<string[]> {
+  return await fs.readdir('./src/workflows/')
 }
 
-async function AvailableWorkflows() {
+async function AvailableWorkflows(): Promise<JSX.Element> {
   const workflows = await availableWorkflowsFromDisk()
   const workflowIds = workflows.map((fileName) => fileName.replace('.yaml', ''))
 

--- a/demo-app/src/display-components/PageTitle.tsx
+++ b/demo-app/src/display-components/PageTitle.tsx
@@ -1,6 +1,6 @@
-import { OpenTrussComponent } from '@/types'
+import type { OpenTrussComponentProps } from '@/types'
 
-const PageTitle: OpenTrussComponent = ({ children }) => {
+function PageTitle({ children }: OpenTrussComponentProps): JSX.Element {
   return <h1>{children}</h1>
 }
 

--- a/demo-app/src/display-components/index.ts
+++ b/demo-app/src/display-components/index.ts
@@ -1,4 +1,4 @@
-import { OpenTrussComponent } from '@/types'
+import { type OpenTrussComponent } from '@/types'
 import PageTitle from './PageTitle'
 
 const displayComponents: Record<string, OpenTrussComponent> = {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "scripts": {
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier \"./**/*.{js,ts,json}\" --write --log-level error",
-    "lint:eslint": "eslint \"./**/*.{js,ts,tsx}\" --fix",
+    "lint:eslint": "eslint \"./**/*.{ts,tsx}\" --fix",
     "lint:ci": "npm run lint:prettier:ci && npm run lint:eslint:ci",
     "lint:prettier:ci": "prettier \"./**/*.{js,ts,json}\" --check",
-    "lint:eslint:ci": "eslint \"./**/*.{js,ts,tsx}\""
+    "lint:eslint:ci": "eslint \"./**/*.{ts,tsx}\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "scripts": {
     "lint": "npm run lint:prettier && npm run lint:eslint",
     "lint:prettier": "prettier \"./**/*.{ts,js,json}\" --write --log-level error",
-    "lint:eslint": "eslint \"./**/*.{js,ts,jsx,tsx}\" --fix",
+    "lint:eslint": "eslint \"./**/*.{ts,tsx}\" --fix",
     "lint:ci": "npm run lint:prettier:ci && npm run lint:eslint:ci",
     "lint:prettier:ci": "prettier \"./**/*.{ts,js,json}\" --check",
-    "lint:eslint:ci": "eslint \"./**/*.{js,ts,jsx,tsx}\""
+    "lint:eslint:ci": "eslint \"./**/*.{ts,tsx}\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "scripts": {
     "lint": "npm run lint:prettier && npm run lint:eslint",
-    "lint:prettier": "prettier \"./**/*.{ts,js,json}\" --write --log-level error",
-    "lint:eslint": "eslint \"./**/*.{ts,tsx}\" --fix",
+    "lint:prettier": "prettier \"./**/*.{js,ts,json}\" --write --log-level error",
+    "lint:eslint": "eslint \"./**/*.{js,ts,tsx}\" --fix",
     "lint:ci": "npm run lint:prettier:ci && npm run lint:eslint:ci",
-    "lint:prettier:ci": "prettier \"./**/*.{ts,js,json}\" --check",
-    "lint:eslint:ci": "eslint \"./**/*.{ts,tsx}\""
+    "lint:prettier:ci": "prettier \"./**/*.{js,ts,json}\" --check",
+    "lint:eslint:ci": "eslint \"./**/*.{js,ts,tsx}\""
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.10.0",

--- a/packages/open-truss/src/hello_world/index.ts
+++ b/packages/open-truss/src/hello_world/index.ts
@@ -1,4 +1,4 @@
-function helloWorld() {
+function helloWorld(): string {
   return 'Hello, World!'
 }
 

--- a/packages/open-truss/src/index.ts
+++ b/packages/open-truss/src/index.ts
@@ -1,17 +1,3 @@
 export { default as helloWorld } from './hello_world'
 export * from './utils/yaml'
 export * from './utils/format'
-class Foo {
-  bar: string
-  constructor() {
-    this.bar = 'bar'
-  }
-}
-
-class Bar extends Foo {
-  foo: string
-  constructor() {
-    super()
-    this.foo = 'foo'
-  }
-}

--- a/packages/open-truss/src/utils/format.ts
+++ b/packages/open-truss/src/utils/format.ts
@@ -1,4 +1,4 @@
-import { format as sqlFormat, SqlLanguage } from 'sql-formatter'
+import { format as sqlFormat, type SqlLanguage } from 'sql-formatter'
 
 export type Param = string | number | string[] | number[]
 
@@ -27,12 +27,12 @@ function formatParams(params: Record<string, Param>): Record<string, string> {
   return Object.fromEntries(formattedEntries)
 }
 
-export function formatQuery(template: string, config?: Config) {
+export function formatQuery(template: string, config?: Config): string {
   return sqlFormat(template, {
-    language: config?.language || 'sql',
+    language: config?.language ?? 'sql',
     tabWidth: 4,
     linesBetweenQueries: 2,
     paramTypes: { named: [':'] },
-    params: config?.params && formatParams(config.params),
+    params: config?.params != null ? formatParams(config.params) : undefined,
   })
 }

--- a/packages/open-truss/src/utils/format.ts
+++ b/packages/open-truss/src/utils/format.ts
@@ -29,10 +29,10 @@ function formatParams(params: Record<string, Param>): Record<string, string> {
 
 export function formatQuery(template: string, config?: Config): string {
   return sqlFormat(template, {
-    language: config?.language ?? 'sql',
+    language: config?.language || 'sql',
     tabWidth: 4,
     linesBetweenQueries: 2,
     paramTypes: { named: [':'] },
-    params: config?.params != null ? formatParams(config.params) : undefined,
+    params: config?.params ? formatParams(config.params) : undefined,
   })
 }

--- a/packages/open-truss/src/utils/yaml.ts
+++ b/packages/open-truss/src/utils/yaml.ts
@@ -1,7 +1,7 @@
 import yaml from 'yaml'
 
-type YamlObject = Record<string, YamlType>
-type YamlType = null | number | string | boolean | YamlObject | YamlType[]
+interface YamlObject extends Record<string, YamlType> {}
+type YamlType = null | number | string | boolean | YamlType[] | YamlObject
 
 export function parseYaml(yamlString: string): YamlType {
   return yaml.parse(yamlString)

--- a/packages/open-truss/src/utils/yaml.ts
+++ b/packages/open-truss/src/utils/yaml.ts
@@ -1,14 +1,12 @@
 import yaml from 'yaml'
 
-interface YamlObject {
-  [key: string]: YamlType
-}
+type YamlObject = Record<string, YamlType>
 type YamlType = null | number | string | boolean | YamlObject | YamlType[]
 
 export function parseYaml(yamlString: string): YamlType {
   return yaml.parse(yamlString)
 }
 
-export function stringifyYaml(yamlObject: YamlType) {
+export function stringifyYaml(yamlObject: YamlType): string {
   return yaml.stringify(yamlObject)
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "strict": true /* Enable all strict type-checking options. */
+  }
+}


### PR DESCRIPTION
Building on and targeting #33 as the base to merge into this PR tries to apply the fixes suggested by the linter but also disables a few lint rules per our preferences.

Definitely open to feedback on whether the rules I disabled make sense to everyone and if there are any others we might want to enable or disable.

- `@typescript-eslint/comma-dangle`: https://typescript-eslint.io/rules/comma-dangle/
- `@typescript-eslint/space-before-function-paren`: https://typescript-eslint.io/rules/space-before-function-paren/
- `react/react-in-jsx-scope`: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
- `@typescript-eslint/return-await`: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md
    - this one is weird, it doesn't error locally but does in CI so I had to disable it 🤷‍♂️ 