### PR TITLE
Improve dev env

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -16,12 +16,9 @@ jobs:
       - name: Run CI
         working-directory: ./packages/open-truss
         run: npm ci
-      - name: Build lib
+      - name: Build dist
         working-directory: ./packages/open-truss
         run: npm run build
-      - name: Build lib-esm
-        working-directory: ./packages/open-truss
-        run: npm run build:esm
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/packages/open-truss/.gitignore
+++ b/packages/open-truss/.gitignore
@@ -1,5 +1,4 @@
 # Build folders
-lib/
-lib-esm/
+dist/
 tsconfig.esm.tsbuildinfo
 tsconfig.tsbuildinfo

--- a/packages/open-truss/bin/append-package-json-to-dist
+++ b/packages/open-truss/bin/append-package-json-to-dist
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Directory of open-truss project
+package_dir="${PACKAGE_DIR:-.}"
+cd $package_dir
+
+mkdir -p dist/cjs
+mkdir -p dist/mjs
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF

--- a/packages/open-truss/bin/build
+++ b/packages/open-truss/bin/build
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Directory of open-truss project
+package_dir="${PACKAGE_DIR:-.}"
+cd $package_dir
+
+PACKAGE_DIR=$package_dir bin/append-package-json-to-dist
+
+echo "Running $ tsc --project tsconfig.esm.json"
+tsc --project tsconfig.esm.json
+
+echo "Running $ tsc --project tsconfig.json"
+tsc --project tsconfig.json

--- a/packages/open-truss/bin/tsc-watch
+++ b/packages/open-truss/bin/tsc-watch
@@ -4,6 +4,8 @@
 package_dir="${PACKAGE_DIR:-.}"
 cd $package_dir
 
+PACKAGE_DIR=$package_dir bin/append-package-json-to-dist
+
 # Function to terminate both tsc processes
 terminate_tsc_processes() {
   echo "Terminating TypeScript watch processes..."

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -2,8 +2,8 @@
   "name": "@open-truss/open-truss",
   "version": "0.1.0",
   "description": "Framework for building internal tools",
-  "module": "lib-esm/index.js",
-  "main": "lib/index.js",
+  "module": "dist/mjs/index.js",
+  "main": "dist/cjs/index.js",
   "directories": {
     "doc": "docs"
   },
@@ -17,8 +17,7 @@
     "open-truss": "./bin/open-truss"
   },
   "files": [
-    "lib",
-    "lib-esm",
+    "dist",
     "package.json",
     "tsconfig.json",
     "tsconfig.esm.json",
@@ -38,11 +37,11 @@
   "homepage": "https://github.com/open-truss/open-truss#readme",
   "exports": {
     ".": {
-      "import": "./lib-esm/index.js",
-      "require": "./lib/index.js"
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
-  "typings": "lib/index.d.ts",
+  "typings": "dist/mjs/index.d.ts",
   "dependencies": {
     "sql-formatter": "^13.0.4",
     "ts-node": "^10.9.1",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -8,8 +8,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.json",
-    "build:esm": "tsc --project tsconfig.esm.json",
+    "build": "bin/build",
     "test": "jest",
     "tsc:watch": "bin/tsc-watch"
   },

--- a/packages/open-truss/tsconfig.esm.json
+++ b/packages/open-truss/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "bundler",
-    "outDir": "./lib-esm"
+    "moduleResolution": "node",
+    "outDir": "./dist/mjs"
   }
 }

--- a/packages/open-truss/tsconfig.json
+++ b/packages/open-truss/tsconfig.json
@@ -13,7 +13,7 @@
     "incremental": true,
     "declaration": true,
     "rootDir": "./src",
-    "outDir": "./lib",
+    "outDir": "./dist/cjs",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/packages/open-truss/tsconfig.json
+++ b/packages/open-truss/tsconfig.json
@@ -12,6 +12,8 @@
     "jsx": "preserve",
     "incremental": true,
     "declaration": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "jest"],
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "paths": {
@@ -19,5 +21,5 @@
     }
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts"]
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
 }


### PR DESCRIPTION
resolves https://github.com/open-truss/open-truss/issues/31

## Why

@jonmagic and I found a great [blog post](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html) that gave instructions on how to organize a typescript project like OT in a sane way. We were already following some of the suggestions, but we should implement the rest

## How

This PR implements the rest of the suggestions. Notably, it moves the output javascript files into `dist/cjs` and `dst/mjs` folders and adds `package.json` files to the dist folders. The easiest way to review this PR is commit by commit and reading the comments included, it should be pretty straightforward.

## Testing

I tested these changes in the demo app and application we use at GitHub and everything worked as expected. 

@open-truss/engineers 