### PR TITLE
Add script server for demo app

### DIFF
--- a/demo-app/script/server
+++ b/demo-app/script/server
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Function to terminate both tsc processes
+terminate_tsc_processes() {
+  echo "Terminating TypeScript watch processes..."
+  pkill -P $$
+}
+
+# Trap SIGINT and SIGTERM and call the function to terminate tsc processes
+trap 'terminate_tsc_processes' SIGINT SIGTERM
+
+echo "Running npm run tsc:watch"
+(npm run tsc:watch) &
+
+echo "Runing npm run dev"
+(npm run dev) &
+
+wait

--- a/packages/open-truss/bin/tsc-watch
+++ b/packages/open-truss/bin/tsc-watch
@@ -17,11 +17,11 @@ trap 'terminate_tsc_processes' SIGINT SIGTERM
 
 # Run tsc with --watch for tsconfig.json and capture the output
 echo "Running tsc watch using $(echo $package_dir/tsconfig.json)"
-(tsc --watch --project $package_dir/tsconfig.json) &
+(tsc --watch --preserveWatchOutput --project $package_dir/tsconfig.json) &
 
 # Run tsc with --watch for tsconfig.esm.json and capture the output
 echo "Running tsc watch using $(echo $package_dir/tsconfig.esm.json)"
-(tsc --watch --project $package_dir/tsconfig.esm.json) &
+(tsc --watch --preserveWatchOutput --project $package_dir/tsconfig.esm.json) &
 
 # Wait for both background processes to complete or for a signal to terminate
 wait


### PR DESCRIPTION
## Why

It's kinda annoying to have to open two terminals to run the demo app and start tsc:watch.

## How

This PR combines those two into one `script/server` command

![1  tmux 2023-12-01 at 4 15 33 PM](https://github.com/open-truss/open-truss/assets/4481584/cb60202d-2b0d-4b2b-b5e0-8552d1696722)

@open-truss/engineers 