### PR TITLE
Update rendering engine to support async components

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 demo-app/.next
 packages/open-truss/dist
+packages/open-truss/nextjs/.next

--- a/demo-app/src/open-truss/components/Foo.tsx
+++ b/demo-app/src/open-truss/components/Foo.tsx
@@ -1,6 +1,6 @@
-import { type BaseOpenTrussComponentV1 } from '@open-truss/open-truss'
+import { type BaseOpenTrussComponentV1Props } from '@open-truss/open-truss'
 
-export default function Foo(props: BaseOpenTrussComponentV1): JSX.Element {
+export default function Foo(props: BaseOpenTrussComponentV1Props): JSX.Element {
   return (
     <div>
       <h1>{JSON.stringify(props.data)}</h1>

--- a/packages/open-truss/nextjs/src/open-truss/components/Foo.tsx
+++ b/packages/open-truss/nextjs/src/open-truss/components/Foo.tsx
@@ -1,6 +1,6 @@
-import { type BaseOpenTrussComponentV1 } from '@open-truss/open-truss'
+import { type BaseOpenTrussComponentV1Props } from '@open-truss/open-truss'
 
-export default function Foo(props: BaseOpenTrussComponentV1): JSX.Element {
+export default function Foo(props: BaseOpenTrussComponentV1Props): JSX.Element {
   return (
     <div>
       <h1>{JSON.stringify(props.data)}</h1>

--- a/packages/open-truss/src/components/OTBar.tsx
+++ b/packages/open-truss/src/components/OTBar.tsx
@@ -1,5 +1,7 @@
-import { type BaseOpenTrussComponentV1 } from '@/configuration'
+import { type BaseOpenTrussComponentV1Props } from '@/configuration'
 
-export default function OTBar(props: BaseOpenTrussComponentV1): JSX.Element {
+export default function OTBar(
+  props: BaseOpenTrussComponentV1Props,
+): JSX.Element {
   return <>{JSON.stringify(props.data)}</>
 }

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,4 +1,8 @@
 import type { YamlObject, YamlType } from '../utils/yaml'
+// React types (e.g. JSX) are used by imports
+// such as OT components, so we need to keep this even if not
+// used by this file
+// eslint-disable-next-line
 import type React from 'react'
 import {
   type BaseOpenTrussComponentV1,
@@ -11,17 +15,20 @@ export interface WorkflowSpec {
   workflow: WorkflowV1 // | WorkflowV2
 }
 type BaseOpenTrussComponents = BaseOpenTrussComponentV1 // |BaseOpenTrussComponentV2
-export type COMPONENTS = Record<string, React.FC<BaseOpenTrussComponents>>
-export type ReactTree = Array<React.JSX.Element | ReactTree>
-export type RenderingEngine = () => ReactTree
+export type COMPONENTS = Record<string, BaseOpenTrussComponents>
+export type ReactTree = Array<Promise<ReactTree | JSX.Element>>
+export type RenderingEngine = () => Promise<ReactTree>
+type ConfigurationFunction = (
+  config: YamlObject,
+  data: YamlType,
+) => Promise<ReactTree>
 
-type ConfigurationFunction = (config: YamlObject, data: YamlType) => ReactTree
 export function applyConfiguration(
   COMPONENTS: COMPONENTS,
 ): ConfigurationFunction {
   const components = Object.assign(COMPONENTS, OTCOMPONENTS)
 
-  const configurationFunction: ConfigurationFunction = (config, data) => {
+  const configurationFunction: ConfigurationFunction = async (config, data) => {
     let renderingEngine
 
     const workflow = (config as unknown as WorkflowSpec).workflow

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -16,7 +16,7 @@ export interface WorkflowSpec {
 }
 type BaseOpenTrussComponents = BaseOpenTrussComponentV1 // |BaseOpenTrussComponentV2
 export type COMPONENTS = Record<string, BaseOpenTrussComponents>
-export type ReactTree = Array<Promise<ReactTree | JSX.Element>>
+export type ReactTree = Array<ReactTree | JSX.Element>
 export type RenderingEngine = () => Promise<ReactTree>
 type ConfigurationFunction = (
   config: YamlObject,

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -35,7 +35,7 @@ export function applyConfiguration(
 
     // TODO this version check should be using zod and runtime validation
     if (workflow.version === 1) {
-      renderingEngine = engineV1(components, workflow, data)
+      renderingEngine = engineV1(components, workflow)
     } else {
       throw new Error(`Unsupported config version: ${workflow.version}`)
     }

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -31,24 +31,29 @@ export function engineV1(
   config: WorkflowV1,
 ): RenderingEngine {
   const renderFrames = async (frames: FrameV1[]): Promise<ReactTree> => {
-    return (() => {
-      return frames.map(async ({ view, data, frames: subFrame }, i) => {
-        const { component, props: viewProps } = view
-        const Component = COMPONENTS[component]
-        const props = {
-          key: i,
-          data,
-          config,
-          ...viewProps,
-        }
+    return (async () => {
+      return Promise.all(
+        frames.map(async ({ view, data, frames: subFrame }, i) => {
+          const { component, props: viewProps } = view
+          const Component = COMPONENTS[component]
+          const props = {
+            key: i,
+            data,
+            config,
+            ...viewProps,
+          }
 
-        if (subFrame === undefined) {
-          return await Component({ ...props })
-        } else {
-          const children = <>{renderFrames(subFrame)}</>
-          return await Component({ ...props, children })
-        }
-      })
+          if (subFrame === undefined) {
+            return await Component({ ...props })
+          } else {
+            const subFrames = (await renderFrames(subFrame)).map((child, k) => {
+              return <div key={k}>{child}</div>
+            })
+            const children = <>{subFrames}</>
+            return await Component({ ...props, children })
+          }
+        }),
+      )
     })()
   }
 

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -29,7 +29,6 @@ export interface WorkflowV1 {
 export function engineV1(
   COMPONENTS: COMPONENTS,
   config: WorkflowV1,
-  data: YamlType,
 ): RenderingEngine {
   const renderFrames = async (frames: FrameV1[]): Promise<ReactTree> => {
     return (() => {

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -1,12 +1,16 @@
 import type { YamlObject, YamlType } from '@/utils/yaml'
-import React from 'react'
 import { type RenderingEngine, type ReactTree, type COMPONENTS } from './apply'
 
-export interface BaseOpenTrussComponentV1 {
-  children?: React.ReactNode
+export interface BaseOpenTrussComponentV1Props {
+  key?: number
+  children?: JSX.Element | Promise<JSX.Element>
   data: YamlType
   config: WorkflowV1
 }
+
+export type BaseOpenTrussComponentV1 = (
+  props: BaseOpenTrussComponentV1Props,
+) => JSX.Element | Promise<JSX.Element>
 
 export interface FrameV1 {
   view: {
@@ -27,21 +31,29 @@ export function engineV1(
   config: WorkflowV1,
   data: YamlType,
 ): RenderingEngine {
-  const renderFrames = (frames: FrameV1[]): ReactTree => {
-    return frames.map(({ view, data, frames: subFrame }, i) => {
-      const { component, props } = view
-      const Component = COMPONENTS[component]
-      return subFrame === undefined ? (
-        <Component key={i} data={data} config={config} {...props} />
-      ) : (
-        <Component key={i} data={data} config={config} {...props}>
-          {renderFrames(subFrame)}
-        </Component>
-      )
-    })
+  const renderFrames = async (frames: FrameV1[]): Promise<ReactTree> => {
+    return (() => {
+      return frames.map(async ({ view, data, frames: subFrame }, i) => {
+        const { component, props: viewProps } = view
+        const Component = COMPONENTS[component]
+        const props = {
+          key: i,
+          data,
+          config,
+          ...viewProps,
+        }
+
+        if (subFrame === undefined) {
+          return await Component({ ...props })
+        } else {
+          const children = <>{renderFrames(subFrame)}</>
+          return await Component({ ...props, children })
+        }
+      })
+    })()
   }
 
-  return () => {
+  return async () => {
     return renderFrames(config.frames)
   }
 }


### PR DESCRIPTION
## Why

To leverage React Server Components we need the ability to support async open truss components

## How

This PR updates the type defs of our rendering engine so that it supports async open truss components. Some things of note:
- We ran into issues where calling `<Component key={i} data={data} config={config} {...props} />` would throw type errors because we updated the type to where Component could now also be a `Promise<JSX.Element>` in addition to `JSX.Element`. It took a while but I figured out the issue was `<Component />` was the incorrect way to call a promise. Instead this code just calls `Component` as a function instead of the syntactic sugar and `awaits` the promise.
- I dropped the usage of `React.FC<>`. After googling around I found that this is no longer the recommended way to declare React component types. The particular issue we were running into was the `React.FC<>` type does not support async function components. This is because it was made at a time when components needed to be synchronous.

@kmcq This PR updates the interface for OT components. We may want to merge this PR first then update [your PR](https://github.com/open-truss/open-truss/pull/59) to use the new interface. @jonmagic this may apply to your trino demo PR as well. 