### PR TITLE
Add graphql query and REST endpoint for executing synchronous uqi query

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -22,6 +22,7 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "encoding": "^0.1.13",
         "eslint": "^8",
         "eslint-config-next": "13.5.5",
         "typescript": "^5"
@@ -1636,6 +1637,27 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "devOptional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "devOptional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -25,6 +25,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "encoding": "^0.1.13",
     "eslint": "^8",
     "eslint-config-next": "13.5.5",
     "typescript": "^5"

--- a/demo-app/src/app/api/graphql/route.ts
+++ b/demo-app/src/app/api/graphql/route.ts
@@ -2,22 +2,46 @@ import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { gql } from 'graphql-tag'
 import { type NextRequest } from 'next/server'
+import synchronousUqiQuery from './synchronous-uqi-query'
 
 const resolvers = {
   Query: {
-    hello: () => 'world',
+    synchronousUqiQuery,
   },
 }
 
 const typeDefs = gql`
   type Query {
-    hello: String
+    synchronousUqiQuery(source: String!, query: String!): UqiQueryResult!
+  }
+
+  type UqiQueryResult {
+    rows: [UqiQueryRow!]!
+    metadata: UqiQueryMetadata!
+  }
+
+  type UqiQueryRow {
+    values: [UqiQueryValue!]!
+  }
+
+  type UqiQueryValue {
+    key: String!
+    type: String!
+    value: String
+  }
+
+  type UqiQueryMetadata {
+    columns: [UqiQueryColumn!]!
+  }
+
+  type UqiQueryColumn {
+    name: String!
+    type: String!
   }
 `
 
 const server = new ApolloServer({
   resolvers,
-
   typeDefs,
 })
 

--- a/demo-app/src/app/api/graphql/synchronous-uqi-query.ts
+++ b/demo-app/src/app/api/graphql/synchronous-uqi-query.ts
@@ -1,0 +1,64 @@
+import sources from '@/lib/uqi-sources'
+import { type UqiMetadata } from '@open-truss/open-truss'
+
+interface SynchronousQueryResult {
+  rows: SynchronousQueryRow[]
+  metadata: SynchronousQueryMetadata
+}
+
+interface SynchronousQueryRow {
+  values: SynchronousQueryValue[]
+}
+
+interface SynchronousQueryValue {
+  key: string
+  type: string
+  value: string
+}
+
+interface SynchronousQueryMetadata {
+  columns: SynchronousQueryColumn[]
+}
+
+interface SynchronousQueryColumn {
+  name: string
+  type: string
+}
+
+interface Args {
+  source: string
+  query: string
+}
+
+async function synchronousUqiQuery(
+  _object: unknown,
+  { source, query }: Args,
+  _context: unknown,
+): Promise<SynchronousQueryResult> {
+  const { config, createClient } = sources[source as keyof typeof sources]
+  const client = await createClient(config)
+  const queryIterator = await client.query(query)
+  const rows = []
+  let metadata: UqiMetadata = {
+    columns: [],
+  }
+  for await (const { row, metadata: m } of queryIterator) {
+    if (metadata.columns.length === 0) {
+      metadata = m
+    }
+    const values = Object.entries(row).map(([key, value]) => ({
+      key,
+      // TODO: cache the type mapping?
+      type: m.columns.find((column) => column.name === key)?.type || 'unknown',
+      value: String(value),
+    }))
+    rows.push({ values })
+  }
+
+  return {
+    rows,
+    metadata,
+  }
+}
+
+export default synchronousUqiQuery

--- a/demo-app/src/app/api/synchronous-uqi-query/route.ts
+++ b/demo-app/src/app/api/synchronous-uqi-query/route.ts
@@ -1,0 +1,16 @@
+import synchronousUqiQuery from '@/app/api/graphql/synchronous-uqi-query'
+import { type NextRequest } from 'next/server'
+
+const handler = async (request: NextRequest): Promise<Response> => {
+  const args = await request.json()
+  const result = await synchronousUqiQuery(null, args, null)
+  return new Response(JSON.stringify(result), {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+  return handler(request)
+}

--- a/demo-app/src/lib/trino-uqi-client.ts
+++ b/demo-app/src/lib/trino-uqi-client.ts
@@ -8,12 +8,12 @@ import {
 } from '@open-truss/open-truss'
 import {
   BasicAuth,
-  type QueryResult,
   Trino,
+  type QueryResult,
   type Iterator as TrinoIterator,
 } from 'trino-client'
 
-interface TrinoConfig {
+export interface TrinoConfig {
   auth?: string
   server: string
   source?: string

--- a/demo-app/src/lib/uqi-sources.ts
+++ b/demo-app/src/lib/uqi-sources.ts
@@ -4,7 +4,7 @@ const sources = {
   'trino-demo': {
     config: {
       auth: 'trino',
-      server: 'http://trino.orb.local:8080',
+      server: 'http://localhost:8080',
     },
     createClient: createTrinoUqiClient,
   },

--- a/demo-app/src/lib/uqi-sources.ts
+++ b/demo-app/src/lib/uqi-sources.ts
@@ -1,0 +1,13 @@
+import createTrinoUqiClient from '@/lib/trino-uqi-client'
+
+const sources = {
+  'trino-demo': {
+    config: {
+      auth: 'trino',
+      server: 'http://trino.orb.local:8080',
+    },
+    createClient: createTrinoUqiClient,
+  },
+}
+
+export default sources


### PR DESCRIPTION
## Why?

I want to start working on react hooks for interacting with the unified query interface but first I need some backend endpoints to hit to execute synchronous uqi queries.

## How?

Review commit by commit.

## Demo

```bash
cd demo-app
npm install
script/server
```

**Note:** Don't forget to start trino! See [these instructions](https://trino.io/docs/current/installation/containers.html#running-the-container)

### GraphQL

Test the graphql endpoint by loading http://localhost:3000/api/graphql and executing this query:

```graphql
query Query($source: String!, $query: String!) {
  synchronousUqiQuery(source: $source, query: $query) {
    rows {
      values {
        key
        type
        value
      }
    }
    metadata {
      columns {
        name
        type
      }
    }
  }
}
```

With these variables:

```json
{
  "source": "trino-demo",
  "query": "select * from  tpch.sf1.customer limit 10"
}
```

### REST

```bash
curl -XPOST \
  -d'{"source":"trino-demo","query":"select * from  tpch.sf1.customer limit 10"}' \
  http://localhost:3000/api/synchronous-uqi-query
```