### PR TITLE
Consolidate component getting and fix up types

### DIFF
--- a/demo-app/src/app/ot/playground/[slug]/page.tsx
+++ b/demo-app/src/app/ot/playground/[slug]/page.tsx
@@ -2,12 +2,6 @@
 import path from 'path'
 import RenderFromEndpoint from '@/components/RenderFromEndpoint'
 
-// TODO: Set COMPONENT_INDEX in application config and OT loads it?
-import * as COMPONENTS from '@/open-truss/components'
-
-// TODO: Get this path from application config and only need to pass in filename?
-const CONFIG_API = '/ot/api/configs/'
-
 export default function Page({
   params: { slug },
 }: {
@@ -20,10 +14,7 @@ export default function Page({
   return (
     <>
       <h1>{sanitizedSlug}</h1>
-      <RenderFromEndpoint
-        components={COMPONENTS}
-        url={`${CONFIG_API}${sanitizedSlug}`}
-      />
+      <RenderFromEndpoint configName={sanitizedSlug} />
     </>
   )
 }

--- a/demo-app/src/app/ot/rsc-playground/[slug]/page.tsx
+++ b/demo-app/src/app/ot/rsc-playground/[slug]/page.tsx
@@ -1,12 +1,6 @@
 import path from 'path'
 import RenderFromFile from '@/components/RenderFromFile'
 
-// TODO: Set COMPONENT_INDEX in application config and OT loads it?
-import * as COMPONENTS from '@/open-truss/components'
-
-// TODO: Get this path from application config and only need to pass in filename?
-const CONFIG_DIR = './src/open-truss/configs/'
-
 export default function Page({
   params: { slug },
 }: {
@@ -19,10 +13,7 @@ export default function Page({
   return (
     <>
       <h1>{sanitizedSlug}</h1>
-      <RenderFromFile
-        components={COMPONENTS}
-        path={`${CONFIG_DIR}${sanitizedSlug}.yaml`}
-      />
+      <RenderFromFile configName={sanitizedSlug} />
     </>
   )
 }

--- a/demo-app/src/components/RenderFromEndpoint.tsx
+++ b/demo-app/src/components/RenderFromEndpoint.tsx
@@ -5,14 +5,20 @@ import {
   type COMPONENTS,
 } from '@open-truss/open-truss'
 
+// TODO: Set COMPONENT_INDEX in application config and OT loads it?
+import * as _components from '@/open-truss/components'
+const components = _components as unknown as COMPONENTS
+
+// TODO: Get this path from application config and only need to pass in filename?
+const CONFIG_API = '/ot/api/configs/'
+
 export default function RenderFromEndpoint({
-  components = {},
-  url,
+  configName,
 }: {
-  components?: COMPONENTS
-  url: string
+  configName: string
 }): JSX.Element {
   // TODO: Use UQI's REST client once that exists?
+  const url = `${CONFIG_API}${configName}`
   const [config, setConfig] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState<boolean>(false)
   const [error, setError] = React.useState<Error | null>(null)

--- a/demo-app/src/components/RenderFromFile.tsx
+++ b/demo-app/src/components/RenderFromFile.tsx
@@ -6,13 +6,19 @@ import {
 import { promises as fs } from 'fs'
 import { notFound } from 'next/navigation'
 
+// TODO: Set COMPONENT_INDEX in application config and OT loads it?
+import * as _components from '@/open-truss/components'
+const components = _components as unknown as COMPONENTS
+
+// TODO: Get this path from application config and only need to pass in filename?
+const CONFIG_DIR = './src/open-truss/configs/'
+
 export default async function RenderFromFile({
-  components = {},
-  path,
+  configName,
 }: {
-  components?: COMPONENTS
-  path: string
+  configName: string
 }): Promise<JSX.Element> {
+  const path = `${CONFIG_DIR}${configName}.yaml`
   let config: string
   try {
     config = await fs.readFile(path, 'utf-8')


### PR DESCRIPTION
## Why?

I noticed after merging #64 that the playground pages were upset with a type error because the `AsyncPageTitle` component doesn't adhere to OT's `BaseOpenTrussComponentV1` type, specifically that it is async and thus doesn't have a ReturnType of `JSX.Element` but instead of `Promise<JSX.Element>`.

## How?

Okay so maybe this is a smell, but I got around this by erasing the types of the imported components.

If we extend `BaseOpenTrussComponentV1` to return `JSX.Element | Promise<JSX.Element>`, then to make things happy we have to add an `async` to the engine, which breaks rendering client components.

### Considerations

I wonder if folks think this solution, erasing the types of the imported components, is unacceptable. If it is, perhaps now is the time to discuss dropping RSC or not.

I think there may be another solution in here somewhere that we could explore to use a generic type or an `allowAsync` argument to the engine and switching on one of those to do the async stuff or not.