### PR TITLE
Convert all types to zod

### DIFF
--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "sql-formatter": "^13.0.4",
         "ts-node": "^10.9.1",
-        "yaml": "^2.3.4"
+        "yaml": "^2.3.4",
+        "zod": "^3.22.4"
       },
       "bin": {
         "open-truss": "bin/open-truss"
@@ -6605,6 +6606,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -11504,6 +11513,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     }
   }
 }

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -45,17 +45,18 @@
   "dependencies": {
     "sql-formatter": "^13.0.4",
     "ts-node": "^10.9.1",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/react": "^18.2.0",
     "@types/jest": "^29.5.8",
+    "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "eslint": "^8.52.0",
     "eslint-plugin-react": "^7.33.2",
-    "react": "^18.2.0",
     "fs-extra": "^11.2.0",
+    "react": "^18.2.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.2.2"
   },

--- a/packages/open-truss/src/components/README.md
+++ b/packages/open-truss/src/components/README.md
@@ -1,9 +1,9 @@
 Components in this folder must adhere to the open truss component interface. e.g.
 
 ```
-import { BaseOpenTrussComponentV1 } from '@open-truss/open-truss'
+import { BaseOpenTrussComponentV1Props } from '@open-truss/open-truss'
 
-export default async function Foo(props: BaseOpenTrussComponentV1): Promise<JSX.Element> {
+export default async function Foo(props: BaseOpenTrussComponentV1Props): Promise<JSX.Element> {
   return <>
     {JSON.stringify(props.data)}
   </>

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,5 +1,5 @@
-import * as OTCOMPONENTS from '@/components'
-import { type YamlObject, type YamlType } from '@/utils/yaml'
+import * as OTCOMPONENTS from '../components'
+import { type YamlObject, type YamlType } from '../utils/yaml'
 import {
   type BaseOpenTrussComponentV1,
   type WorkflowV1,

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,9 +1,3 @@
-// React types (e.g. JSX) are used by imports
-// such as OT components, so we need to keep this even if not
-// used by this file
-// eslint-disable-next-line
-import type React from 'react'
-
 import * as OTCOMPONENTS from '../components'
 import { type YamlObject, type YamlType } from '../utils/yaml'
 import {

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,5 +1,5 @@
-import * as OTCOMPONENTS from '../components'
-import { type YamlObject, type YamlType } from '../utils/yaml'
+import * as OTCOMPONENTS from '@/components'
+import { type YamlObject, type YamlType } from '@/utils/yaml'
 import {
   type BaseOpenTrussComponentV1,
   type WorkflowV1,

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { YamlObjectShape, YamlShape } from '@/utils/yaml'
+import { YamlObjectShape, YamlShape } from '../utils/yaml'
 import { type RenderingEngine, type ReactTree, type COMPONENTS } from './apply'
 import { z } from 'zod'
 

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { YamlObject, YamlType } from '@/utils/yaml'
 import { type RenderingEngine, type ReactTree, type COMPONENTS } from './apply'
 
-type Components = JSX.Element
+type Components = React.JSX.Element
 
 export interface BaseOpenTrussComponentV1Props {
   key?: number

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -34,7 +34,9 @@ export const BaseOpenTrussComponentV1PropsShape = z.object({
   config: WorkflowV1Shape,
 })
 
-export type BaseOpenTrussComponentV1Props = z.infer<typeof BaseOpenTrussComponentV1PropsShape>
+export type BaseOpenTrussComponentV1Props = z.infer<
+  typeof BaseOpenTrussComponentV1PropsShape
+>
 
 export type BaseOpenTrussComponentV1 = (
   props: z.infer<typeof BaseOpenTrussComponentV1PropsShape>,

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -1,33 +1,44 @@
 import React from 'react'
-import type { YamlObject, YamlType } from '@/utils/yaml'
+import { YamlObjectShape, YamlShape } from '@/utils/yaml'
 import { type RenderingEngine, type ReactTree, type COMPONENTS } from './apply'
+import { z } from 'zod'
 
 type Components = React.JSX.Element
 
-export interface BaseOpenTrussComponentV1Props {
-  key?: number
-  children?: Components
-  data: YamlType
-  config: WorkflowV1
+const FrameBase = z.object({
+  view: z.object({
+    component: z.string(),
+    props: YamlObjectShape,
+  }),
+  data: z.string(),
+})
+
+type FrameType = z.infer<typeof FrameBase> & {
+  frames: FrameType[]
 }
+
+const FrameV1Shape: z.ZodType<FrameType> = FrameBase.extend({
+  frames: z.lazy(() => FrameV1Shape).array(),
+})
+type FrameV1 = z.infer<typeof FrameV1Shape>
+
+const WorkflowV1Shape = z.object({
+  version: z.number(),
+  frames: FrameV1Shape.array(),
+})
+export type WorkflowV1 = z.infer<typeof WorkflowV1Shape>
+
+export const BaseOpenTrussComponentV1PropsShape = z.object({
+  data: YamlShape,
+  children: z.any().optional(),
+  config: WorkflowV1Shape,
+})
+
+export type BaseOpenTrussComponentV1Props = z.infer<typeof BaseOpenTrussComponentV1PropsShape>
 
 export type BaseOpenTrussComponentV1 = (
-  props: BaseOpenTrussComponentV1Props,
+  props: z.infer<typeof BaseOpenTrussComponentV1PropsShape>,
 ) => Components
-
-export interface FrameV1 {
-  view: {
-    component: string
-    props: YamlObject
-  }
-  frames?: FrameV1[]
-  data: YamlType
-}
-
-export interface WorkflowV1 {
-  version: number
-  frames: FrameV1[]
-}
 
 export function engineV1(
   COMPONENTS: COMPONENTS,

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -10,7 +10,7 @@ const FrameBase = z.object({
     component: z.string(),
     props: YamlObjectShape,
   }),
-  data: z.string(),
+  data: YamlShape,
 })
 
 type FrameType = z.infer<typeof FrameBase> & {

--- a/packages/open-truss/src/utils/yaml.ts
+++ b/packages/open-truss/src/utils/yaml.ts
@@ -1,4 +1,5 @@
 import yaml from 'yaml'
+import { z } from 'zod'
 
 export interface YamlObject extends Record<string, YamlType> {}
 export type YamlType =
@@ -8,6 +9,14 @@ export type YamlType =
   | boolean
   | YamlType[]
   | YamlObject
+
+const yamlScalars = z.union([z.null(), z.number(), z.string(), z.boolean()])
+
+export const YamlShape: z.ZodType<YamlType> = yamlScalars
+  // Use zod's lazy function to recursively add in an array and object of YamlShape
+  .or(z.lazy(() => YamlShape.array()))
+  .or(z.lazy(() => YamlObjectShape))
+export const YamlObjectShape = z.record(z.string(), YamlShape)
 
 export function parseYaml(yamlString: string): YamlObject {
   return yaml.parse(yamlString)


### PR DESCRIPTION
## Why?

I want to create a UX for building configs and to do that it will be helpful to inspect a component's props at runtime.

## How?

[`zod`](https://zod.dev/) is a popular runtime validation library that also has great TypeScript support. In this PR I've converted all our types to use `zod`. Well, almost all, Yaml is super recursive which is difficult, but I got it handled!

**NOTE:** I didn't bump the engine version as there are no breaking changes here. In fact, there are no changes at all! The exported types should be equivalent.

In a subsequent PR I'll show you how we can inspect zod's prop descriptions at runtime and build a UX on top of it. I've already validated this so I think this approach is worthwhile. I want to merge this sooner than I'll get to the next part since it's a pain to update these types.
