### PR TITLE
Fix issue where subframes weren't getting keys

### DIFF
--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { YamlObjectShape, YamlShape } from '../utils/yaml'
-import { type RenderingEngine, type ReactTree, type COMPONENTS } from './apply'
 import { z } from 'zod'
+import { YamlObjectShape, YamlShape } from '../utils/yaml'
+import { type COMPONENTS, type ReactTree, type RenderingEngine } from './apply'
 
 type Components = React.JSX.Element
 
@@ -69,7 +69,11 @@ export function engineV1(
           )
         })
         const children = <>{subFrames}</>
-        return <Component key={i} {...props}>{children}</Component>
+        return (
+          <Component key={i} {...props}>
+            {children}
+          </Component>
+        )
       }
     })
   }

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -51,7 +51,6 @@ export function engineV1(
       const { component, props: viewProps } = view
       const Component = COMPONENTS[component]
       const props = {
-        key: i,
         data,
         config,
         ...viewProps,
@@ -62,7 +61,7 @@ export function engineV1(
       }
 
       if (subFrame === undefined) {
-        return Component({ ...props })
+        return <Component key={i} {...props} />
       } else {
         const subFrames = renderFrames(subFrame).map((child, k) => {
           return (
@@ -70,7 +69,7 @@ export function engineV1(
           )
         })
         const children = <>{subFrames}</>
-        return Component({ ...props, children })
+        return <Component key={i} {...props}>{children}</Component>
       }
     })
   }


### PR DESCRIPTION
## Why?

I was getting console warnings about components not having unique keys. It turns out that calling the component as a function like this breaks that. Since we don't need to `await` these anymore, we can just construct JSX per usual.

## How?

Please notice my branch name :)
