### PR TITLE
engine-v1: type improvements, handle named exports, catch misbehaving children

### DIFF
--- a/packages/open-truss/src/components/index.ts
+++ b/packages/open-truss/src/components/index.ts
@@ -1,1 +1,3 @@
-export { default as OTExampleComponent } from './OTExampleComponent'
+import * as _OTExampleComponent from './OTExampleComponent'
+export const OTExampleComponent = _OTExampleComponent
+export const OT_COMPONENTS = { OTExampleComponent }

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,4 +1,4 @@
-import * as OTCOMPONENTS from '../components'
+import { OT_COMPONENTS } from '../components'
 import { type YamlObject, type YamlType } from '../utils/yaml'
 import {
   type BaseOpenTrussComponentV1,
@@ -21,7 +21,7 @@ type ConfigurationFunction = (
 export function applyConfiguration(
   COMPONENTS: COMPONENTS,
 ): ConfigurationFunction {
-  const components = Object.assign(COMPONENTS, OTCOMPONENTS)
+  const components = Object.assign(COMPONENTS, OT_COMPONENTS)
 
   const configurationFunction: ConfigurationFunction = (config, data) => {
     let renderingEngine: RenderingEngine

--- a/packages/open-truss/src/configuration/apply.tsx
+++ b/packages/open-truss/src/configuration/apply.tsx
@@ -1,3 +1,4 @@
+import { type z } from 'zod'
 import { OT_COMPONENTS } from '../components'
 import { type YamlObject, type YamlType } from '../utils/yaml'
 import {
@@ -9,8 +10,14 @@ import {
 export interface WorkflowSpec {
   workflow: WorkflowV1 // | WorkflowV2
 }
-type BaseOpenTrussComponents = BaseOpenTrussComponentV1 // |BaseOpenTrussComponentV2
-export type COMPONENTS = Record<string, BaseOpenTrussComponents>
+type OpenTrussComponent = BaseOpenTrussComponentV1 // |BaseOpenTrussComponentV2
+export interface OpenTrussComponentExports {
+  default: OpenTrussComponent
+  Props: z.AnyZodObject
+}
+export type COMPONENTS =
+  | Record<string, OpenTrussComponent>
+  | Record<string, OpenTrussComponentExports>
 export type ReactTree = Array<ReactTree | JSX.Element>
 export type RenderingEngine = () => ReactTree
 type ConfigurationFunction = (

--- a/packages/open-truss/src/configuration/engine-v1.tsx
+++ b/packages/open-truss/src/configuration/engine-v1.tsx
@@ -11,19 +11,23 @@ import {
 const DataShape = YamlShape.optional()
 
 const FrameBase = z.object({
+  frame: z.null(), // used only to make configs more readable
   view: z.object({
     component: z.string(),
-    props: YamlObjectShape,
+    props: YamlObjectShape.optional(),
   }),
   data: DataShape,
 })
 
-type FrameType = z.infer<typeof FrameBase> & {
-  frames: FrameType[]
+export type FrameType = z.infer<typeof FrameBase> & {
+  frames?: FrameType[]
 }
 
 const FrameV1Shape: z.ZodType<FrameType> = FrameBase.extend({
-  frames: z.lazy(() => FrameV1Shape).array(),
+  frames: z
+    .lazy(() => FrameV1Shape)
+    .array()
+    .optional(),
 })
 type FrameV1 = z.infer<typeof FrameV1Shape>
 


### PR DESCRIPTION
While working on my config builder UX I noticed a few things could be improved.

- Add OT_COMPONENTS as an export of all OT components.
- engine-v1 supports components that have named exports.
  - This is important as I want to introduce exporting a `Props` constant to inspect a component's prop types.
- Mark some optional props as optional.
- Throw an error when children aren't supported but are attempted to be used.
