### PR TITLE
First draft of config builder

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^18",
         "react-dom": "^18",
         "trino-client": "^0.2.2",
-        "yaml": "^2.3.3"
+        "yaml": "^2.3.3",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -4972,6 +4973,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -19,7 +19,8 @@
     "react": "^18",
     "react-dom": "^18",
     "trino-client": "^0.2.2",
-    "yaml": "^2.3.3"
+    "yaml": "^2.3.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/demo-app/src/app/ot/config-builder/page.tsx
+++ b/demo-app/src/app/ot/config-builder/page.tsx
@@ -47,7 +47,7 @@ function PropInput({
   value?: string
 }): React.JSX.Element | null {
   const defaultValue = type.defaultValue as string
-  value = value || defaultValue
+  value = value ?? defaultValue
 
   useEffect(() => {
     onChange(defaultValue)
@@ -58,7 +58,23 @@ function PropInput({
   }
 
   switch (type.type) {
-    case 'ZodString': {
+    case 'ZodUndefined':
+    case 'ZodNull':
+    case 'ZodVoid':
+      return null
+    case 'ZodNumber':
+    case 'ZodBigInt':
+      return (
+        <input
+          name={name}
+          type="number"
+          value={Number(value)}
+          onChange={(e) => {
+            onChange(Number(e.target.value))
+          }}
+        />
+      )
+    case 'ZodString':
       return (
         <input
           name={name}
@@ -69,7 +85,22 @@ function PropInput({
           }}
         />
       )
-    }
+    case 'ZodBoolean':
+      return (
+        <div>
+          <label htmlFor={name}>{name}</label>
+          <input
+            type="checkbox"
+            id={name}
+            name={name}
+            placeholder={name}
+            checked={Boolean(value)}
+            onChange={(e) => {
+              onChange(e.target.checked)
+            }}
+          />
+        </div>
+      )
     case 'ZodEnum':
       if (Array.isArray(type?.shape)) {
         const enumOptions = type.shape.map((option: string) => (

--- a/demo-app/src/app/ot/config-builder/page.tsx
+++ b/demo-app/src/app/ot/config-builder/page.tsx
@@ -192,15 +192,19 @@ export default function ConfigBuilderPage(): React.JSX.Element {
 
   return (
     <ConfigBuilderContext.Provider value={{ config, setConfig }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', padding: 10 }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: 10,
+        }}
+      >
         <div>
           <ComponentList />
           <h2>config</h2>
           <pre>{config.replaceAll('frame: null', 'frame:')}</pre>
         </div>
-        <div>
-          {config !== CONFIG_BASE && <RenderConfig config={config} />}
-        </div>
+        <div>{config !== CONFIG_BASE && <RenderConfig config={config} />}</div>
       </div>
     </ConfigBuilderContext.Provider>
   )

--- a/demo-app/src/app/ot/config-builder/page.tsx
+++ b/demo-app/src/app/ot/config-builder/page.tsx
@@ -1,0 +1,207 @@
+'use client'
+import { useContext, useEffect, useState, createContext } from 'react'
+import {
+  describeZod,
+  type COMPONENTS,
+  OT_COMPONENTS,
+  type FrameType,
+  type OpenTrussComponentExports,
+  type YamlType,
+  type WorkflowSpec,
+  type ZodDescriptionObject,
+  parseYaml,
+  stringifyYaml,
+} from '@open-truss/open-truss'
+import * as APP_COMPONENTS from '@/open-truss/components'
+import RenderConfig from '@/components/RenderConfig'
+const ALL_COMPONENTS = {
+  ...APP_COMPONENTS,
+  ...OT_COMPONENTS,
+} as unknown as COMPONENTS
+
+type ViewProps = FrameType['view']['props']
+
+const CONFIG_BASE = `
+workflow:
+  version: 1
+`.trim()
+
+interface ConfigBuilder {
+  config: string
+  setConfig: (config: string) => void
+}
+const ConfigBuilderContext = createContext<ConfigBuilder>({
+  config: CONFIG_BASE,
+  setConfig: (_c: string) => null,
+})
+
+function PropInput({
+  name,
+  onChange,
+  type,
+  value,
+}: {
+  name: string
+  onChange: (value: YamlType) => void
+  type: ZodDescriptionObject
+  value?: string
+}): React.JSX.Element | null {
+  const defaultValue = type.defaultValue as string
+  value = value || defaultValue
+
+  useEffect(() => {
+    onChange(defaultValue)
+  }, [defaultValue])
+
+  if (name === 'children') {
+    return null
+  }
+
+  switch (type.type) {
+    case 'ZodString': {
+      return (
+        <input
+          name={name}
+          placeholder={name}
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value)
+          }}
+        />
+      )
+    }
+    case 'ZodEnum':
+      if (Array.isArray(type?.shape)) {
+        const enumOptions = type.shape.map((option: string) => (
+          <div key={option}>
+            <label htmlFor={option}>{option}</label>
+            <input
+              type="radio"
+              id={option}
+              name={option}
+              value={option}
+              checked={value === option}
+              onChange={(e) => {
+                onChange(e.target.value)
+              }}
+            />
+          </div>
+        ))
+        return <>{enumOptions}</>
+      }
+  }
+
+  return (
+    <div>
+      Name: {name}. type: {JSON.stringify(type)}
+    </div>
+  )
+}
+
+function PropInputs({
+  componentName,
+  onChange,
+  props,
+}: {
+  componentName: string
+  onChange: (propName: string) => (value: YamlType) => void
+  props: ViewProps
+}): React.JSX.Element | null {
+  const component = ALL_COMPONENTS[componentName]
+  if (!hasPropsExport(component)) {
+    return null
+  }
+  const niceProps = describeZod(component.Props.shape)
+
+  return (
+    <div>
+      {Object.entries(niceProps).map(([propName, propType]) => {
+        return (
+          <PropInput
+            key={propName}
+            onChange={onChange(propName)}
+            name={propName}
+            type={propType}
+            value={props ? (props[propName] as string) : undefined}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function hasPropsExport(
+  component: any,
+): component is OpenTrussComponentExports {
+  return 'Props' in component
+}
+
+function ComponentListItem({
+  componentName,
+}: {
+  componentName: string
+}): React.JSX.Element {
+  const { config, setConfig } = useContext(ConfigBuilderContext)
+  const [props, setProps] = useState<ViewProps>(undefined)
+  const parsedConfig = parseYaml(config) as unknown as WorkflowSpec
+
+  const frame: FrameType = {
+    frame: null, // Makes the config easier to read
+    view: { component: componentName, props },
+  }
+  const addFrame = (): void => {
+    const frames = (parsedConfig.workflow.frames || []).concat(frame)
+    setConfig(
+      stringifyYaml({
+        ...parsedConfig,
+        workflow: { ...parsedConfig.workflow, frames },
+      }),
+    )
+  }
+  const onChange = (propName: string) => (value: YamlType) => {
+    setProps((currentProps) => ({ ...currentProps, [propName]: value }))
+  }
+
+  return (
+    <div>
+      {componentName}
+      <button onClick={addFrame}>Add</button>
+      <PropInputs
+        componentName={componentName}
+        onChange={onChange}
+        props={props}
+      />
+      <br />
+      <br />
+    </div>
+  )
+}
+
+function ComponentList(): React.JSX.Element {
+  return (
+    <div>
+      {Object.keys(ALL_COMPONENTS).map((componentName) => (
+        <ComponentListItem key={componentName} componentName={componentName} />
+      ))}
+    </div>
+  )
+}
+
+export default function ConfigBuilderPage(): React.JSX.Element {
+  const [config, setConfig] = useState<string>(CONFIG_BASE)
+
+  return (
+    <ConfigBuilderContext.Provider value={{ config, setConfig }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', padding: 10 }}>
+        <div>
+          <ComponentList />
+          <h2>config</h2>
+          <pre>{config.replaceAll('frame: null', 'frame:')}</pre>
+        </div>
+        <div>
+          {config !== CONFIG_BASE && <RenderConfig config={config} />}
+        </div>
+      </div>
+    </ConfigBuilderContext.Provider>
+  )
+}

--- a/demo-app/src/components/RenderConfig.tsx
+++ b/demo-app/src/components/RenderConfig.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import {
+  applyConfiguration,
+  parseYaml,
+  type COMPONENTS,
+} from '@open-truss/open-truss'
+
+// TODO: Set COMPONENT_INDEX in application config and OT loads it?
+import * as _components from '@/open-truss/components'
+const components = _components as unknown as COMPONENTS
+
+export default function RenderConfig({
+  config,
+}: {
+  config: string
+}): JSX.Element {
+  const configurationFunction = React.useMemo(
+    () => applyConfiguration(components),
+    [],
+  )
+
+  const renderedComponents = React.useMemo(() => {
+    if (config) {
+      const parsedConfig = parseYaml(config)
+      return configurationFunction(parsedConfig, {})
+    }
+  }, [config])
+
+  return <>{renderedComponents}</>
+}

--- a/demo-app/src/components/RenderFromEndpoint.tsx
+++ b/demo-app/src/components/RenderFromEndpoint.tsx
@@ -1,13 +1,5 @@
 import React from 'react'
-import {
-  applyConfiguration,
-  parseYaml,
-  type COMPONENTS,
-} from '@open-truss/open-truss'
-
-// TODO: Set COMPONENT_INDEX in application config and OT loads it?
-import * as _components from '@/open-truss/components'
-const components = _components as unknown as COMPONENTS
+import RenderConfig from './RenderConfig'
 
 // TODO: Get this path from application config and only need to pass in filename?
 const CONFIG_API = '/ot/api/configs/'
@@ -20,7 +12,7 @@ export default function RenderFromEndpoint({
   // TODO: Use UQI's REST client once that exists?
   const url = `${CONFIG_API}${configName}`
   const [config, setConfig] = React.useState<string | null>(null)
-  const [loading, setLoading] = React.useState<boolean>(false)
+  const [loading, setLoading] = React.useState<boolean>(true)
   const [error, setError] = React.useState<Error | null>(null)
   React.useEffect(() => {
     const fetchConfig = async (): Promise<void> => {
@@ -35,23 +27,13 @@ export default function RenderFromEndpoint({
     setLoading(false)
   }, [url])
 
-  const configurationFunction = React.useMemo(
-    () => applyConfiguration(components),
-    [],
-  )
-
-  const renderedComponents = React.useMemo(() => {
-    if (config) {
-      const parsedConfig = parseYaml(config)
-      return configurationFunction(parsedConfig, {})
-    }
-  }, [config])
-
   if (error) {
     return <>OOPS! {error.message}</>
   } else if (loading) {
     return <>Loading...</>
+  } else if (config) {
+    return <RenderConfig config={config} />
   }
 
-  return <>{renderedComponents}</>
+  return <div>No config :(</div>
 }

--- a/demo-app/src/components/RenderFromFile.tsx
+++ b/demo-app/src/components/RenderFromFile.tsx
@@ -1,14 +1,6 @@
-import {
-  applyConfiguration,
-  parseYaml,
-  type COMPONENTS,
-} from '@open-truss/open-truss'
 import { promises as fs } from 'fs'
 import { notFound } from 'next/navigation'
-
-// TODO: Set COMPONENT_INDEX in application config and OT loads it?
-import * as _components from '@/open-truss/components'
-const components = _components as unknown as COMPONENTS
+import RenderConfig from './RenderConfig'
 
 // TODO: Get this path from application config and only need to pass in filename?
 const CONFIG_DIR = './src/open-truss/configs/'
@@ -30,8 +22,9 @@ export default async function RenderFromFile({
     }
   }
 
-  const parsedConfig = parseYaml(config)
-  const renderedComponents = applyConfiguration(components)(parsedConfig, {})
+  if (config) {
+    return <RenderConfig config={config} />
+  }
 
-  return <>{renderedComponents}</>
+  return <div>No config :(</div>
 }

--- a/demo-app/src/open-truss/components/ClientPageTitle.tsx
+++ b/demo-app/src/open-truss/components/ClientPageTitle.tsx
@@ -10,7 +10,7 @@ export const Props = BaseOpenTrussComponentV1PropsShape.extend({
 
 function PageTitle({
   color,
-  headerElement,
+  headerElement = 'h1',
   title,
 }: z.infer<typeof Props>): JSX.Element {
   const Component = headerElement

--- a/demo-app/src/open-truss/components/ClientPageTitle.tsx
+++ b/demo-app/src/open-truss/components/ClientPageTitle.tsx
@@ -1,8 +1,24 @@
 'use client'
-import { type BaseOpenTrussComponentV1Props } from '@open-truss/open-truss'
+import { z } from 'zod'
+import { BaseOpenTrussComponentV1PropsShape } from '@open-truss/open-truss'
 
-function PageTitle({ children }: BaseOpenTrussComponentV1Props): JSX.Element {
-  return <h1>{children}</h1>
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  color: z.string().default('blue'),
+  headerElement: z.enum(['h1', 'h2', 'h3', 'h4', 'h5']).default('h1'),
+  title: z.string().default('Page Title'),
+})
+
+function PageTitle({
+  color,
+  headerElement,
+  title,
+}: z.infer<typeof Props>): JSX.Element {
+  const Component = headerElement
+  return (
+    <Component style={{ color }}>
+      {title} (I am an {headerElement})
+    </Component>
+  )
 }
 
 export default PageTitle

--- a/demo-app/src/open-truss/components/index.ts
+++ b/demo-app/src/open-truss/components/index.ts
@@ -1,3 +1,3 @@
-export { default as AsyncPageTitle } from './AsyncPageTitle'
-export { default as ClientPageTitle } from './ClientPageTitle'
-export { default as YourAppExampleComponent } from './YourAppExampleComponent'
+export * as AsyncPageTitle from './AsyncPageTitle'
+export * as ClientPageTitle from './ClientPageTitle'
+export * as YourAppExampleComponent from './YourAppExampleComponent'

--- a/demo-app/src/open-truss/configs/3-client-example.yaml
+++ b/demo-app/src/open-truss/configs/3-client-example.yaml
@@ -5,4 +5,4 @@ workflow:
       view:
         component: ClientPageTitle
         props:
-          children: This title is from a client component
+          title: This title is from a client component


### PR DESCRIPTION
## Why?

I think having a UX to build configs will help us get folks excited by OT, teach users how to write configs, and make it fun to create new configs.

My other recent PRs that have been building towards this:

- #69
- #70
- #75

## How?

- Refactor `RenderConfig` out of `RenderFrom{Endpoint,File}`.
  - This lets the config builder render its in-memory config that it has built.
- Add `zod` to demo-app
- First draft of config builder UX
  - Currently it only knows how to handle primitive types, but these start to show the possibilities.
  - I updated `ClientPageTitle` to have some silly props to showcase what's possible.
  - The UI is partying like it's 1989.


https://github.com/open-truss/open-truss/assets/3272924/bca0b8ce-abb6-4d51-9186-488df397ea1e

Next up is handling `children` so we can get sub-frames going 🚀 And adding more types, including a recursive handling for arrays and objects.