### PR TITLE
Fix how @open-truss/open-truss package uses react

### DIFF
--- a/demo-app/script/bootstrap
+++ b/demo-app/script/bootstrap
@@ -69,7 +69,15 @@ else
 fi
 
 # Install Node.js dependencies.
-cd $open_truss_package_dir && npm install && cd $demo_app_dir && npm install
+cd $open_truss_package_dir \
+  && npm install \
+  && cd $demo_app_dir \
+  && npm install
+
+# Fix react link
+cd $open_truss_package_dir \
+  && npm link $demo_app_dir/node_modules/react \
+  && cd $demo_app_dir
 
 # Copy .env.local.example to .env.local if .env.local doesn't exist.
 if [ ! -f $demo_app_dir/.env.local ]; then


### PR DESCRIPTION
## Why?

> Invalid Hook Call
> Hooks can only be called inside the body of a function component.
> There are three common reasons you might be seeing it:
> 1. You might have mismatching versions of React and React DOM.
> 2. You might be breaking the [Rules of Hooks](https://legacy.reactjs.org/docs/hooks-rules.html).
> 3. You might have more than one copy of React in the same app.

## How?

Read through https://iws.io/2022/invalid-hook-multiple-react-instances a few times and then updated `script/bootstrap` to create the correct link so the open-truss package is linked to the react version the demo-app is using.