### PR TITLE
Instead of saying what type a prop is, use <Component /> syntax

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.8",
+        "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",

--- a/demo-app/src/open-truss/configs/2-available-workflows.yaml
+++ b/demo-app/src/open-truss/configs/2-available-workflows.yaml
@@ -5,6 +5,4 @@ workflow:
       view:
         component: OTAvailableWorkflowsFromEndpoint
         props:
-          link:
-            type: component
-            value: NextLink
+          link: <NextLink />

--- a/demo-app/src/pages/ot/playground/index.tsx
+++ b/demo-app/src/pages/ot/playground/index.tsx
@@ -9,9 +9,7 @@ workflow:
       view:
         component: OTAvailableWorkflowsFromEndpoint
         props:
-          link:
-            type: component
-            value: NextLink
+          link: <NextLink />
 `
 
 export default function Playground(): JSX.Element {

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.8",
+        "@types/lodash": "^4.14.202",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
@@ -1532,6 +1533,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -7834,6 +7841,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
       "dev": true
     },
     "@types/node": {

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.8",
+    "@types/lodash": "^4.14.202",
     "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -52,6 +52,11 @@ interface ComponentPropsReturnShape {
   data: DataV1
 }
 
+// Checks to see if the prop is a string like "<Component />"
+function isComponent(prop: YamlType): prop is string {
+  return typeof prop === 'string' && prop.startsWith('<') && prop.endsWith('/>')
+}
+
 function processProps({
   config,
   viewProps,
@@ -62,8 +67,8 @@ function processProps({
   if (viewProps !== undefined) {
     for (const propName in viewProps) {
       const prop = viewProps[propName]
-      if (prop.type === 'component') {
-        newProps[propName] = getComponent(prop.value, COMPONENTS)
+      if (isComponent(prop)) {
+        newProps[propName] = getComponent(prop, COMPONENTS)
       }
     }
   }
@@ -80,9 +85,10 @@ export function getComponent(
   component: string,
   COMPONENTS: COMPONENTS,
 ): OpenTrussComponent {
-  let Component = COMPONENTS[component]
+  const componentName = component.replaceAll(/(<|\/>)/g, '').trim()
+  let Component = COMPONENTS[componentName]
   if (!Component) {
-    throw new Error(`No component '${component}' configured.`)
+    throw new Error(`No component '${componentName}' configured.`)
   }
 
   if (hasDefaultExport(Component)) {
@@ -90,7 +96,7 @@ export function getComponent(
   }
 
   if (!Component) {
-    throw new Error(`No component '${component}' configured.`)
+    throw new Error(`No component '${componentName}' configured.`)
   }
 
   return Component

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -22,29 +22,10 @@ workflow:
       view:
         component: OTAvailableWorkflowsFromEndpoint
         props:
-          link:
-            type: component
-            value: NextLink
+          link: <NextLink />
 */
 
-const ViewPropTypeComponent = z.object({
-  type: z.literal('component'),
-  value: z.string(),
-})
-const ViewPropTypeString = z.object({
-  type: z.literal('string'),
-  value: z.string(),
-})
-const ViewPropTypeNumber = z.object({
-  type: z.literal('number'),
-  value: z.number(),
-})
-const ViewPropShape = z.discriminatedUnion('type', [
-  ViewPropTypeComponent,
-  ViewPropTypeString,
-  ViewPropTypeNumber,
-])
-const ViewPropsV1Shape = z.record(z.string(), ViewPropShape).optional()
+const ViewPropsV1Shape = z.record(z.string(), YamlShape).optional()
 export type ViewPropsV1 = z.infer<typeof ViewPropsV1Shape>
 
 // Frame Schemas


### PR DESCRIPTION
This is an alternative solution to the `props[name].type`/`props[name].value` solution from https://github.com/open-truss/open-truss/pull/94: instead of saying that something has `type: component`, I am introducing a syntax way to specify it:

```diff
workflow:
  version: 1
  frames:
    - frame:
      view:
        component: OTAvailableWorkflowsFromEndpoint
        props:
          link:
-           type: component
-           value: NextLink
+         link: <NextLink />
```

While more magical, I like that this removes the need to specify that every string is a string and number is a number; this could really add up to a lot of lines in large configs.

What do you all think?