### PR TITLE
Catch and display frame configuration errors

### DIFF
--- a/demo-app/src/pages/ot/playground/[slug]/index.tsx
+++ b/demo-app/src/pages/ot/playground/[slug]/index.tsx
@@ -15,7 +15,11 @@ export default function Page(): JSX.Element {
   return (
     <>
       <h1>{sanitizedSlug}</h1>
-      <RenderFromEndpoint configName={sanitizedSlug} components={components} />
+      <RenderFromEndpoint
+        configName={sanitizedSlug}
+        components={components}
+        validateConfig={false}
+      />
     </>
   )
 }

--- a/packages/open-truss/src/configuration/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/RenderConfig.tsx
@@ -23,15 +23,23 @@ export type COMPONENTS =
 export function RenderConfig({
   components: appComponents,
   config,
+  validateConfig = true,
 }: {
   components: COMPONENTS
   config: string
+  validateConfig?: boolean
 }): React.JSX.Element {
   const components = Object.assign(appComponents, OT_COMPONENTS)
   const parsedConfig = parseYaml(config)
   const workflow = (parsedConfig as unknown as WorkflowSpec).workflow
   if (workflow.version === 1) {
-    return <RenderConfigV1 COMPONENTS={components} config={workflow} />
+    return (
+      <RenderConfigV1
+        COMPONENTS={components}
+        config={workflow}
+        validateConfig={validateConfig}
+      />
+    )
   } else {
     throw new Error(`Unsupported config version: ${workflow.version}`)
   }
@@ -40,6 +48,7 @@ export function RenderConfig({
 interface RenderFromEndpointInterface {
   components: COMPONENTS
   configName: string
+  validateConfig?: boolean
 }
 
 // TODO: Get this path from application config and only need to pass in filename?
@@ -47,6 +56,7 @@ const CONFIG_API = '/ot/api/configs/'
 export function RenderFromEndpoint({
   configName,
   components,
+  validateConfig = true,
 }: RenderFromEndpointInterface): JSX.Element {
   // TODO: Use UQI's REST client once that exists?
   const url = `${CONFIG_API}${configName}`
@@ -71,7 +81,13 @@ export function RenderFromEndpoint({
   } else if (loading) {
     return <>Loading...</>
   } else if (config) {
-    return <RenderConfig config={config} components={components} />
+    return (
+      <RenderConfig
+        config={config}
+        components={components}
+        validateConfig={validateConfig}
+      />
+    )
   }
 
   return <div>No config :(</div>

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -17,6 +17,33 @@ interface FrameContext {
   configPath: string
 }
 
+class FrameError extends Error {
+  public componentName: string
+  public configPath: string
+
+  constructor(message: string, componentName: string, configPath: string) {
+    super(message)
+    this.componentName = componentName
+    this.configPath = configPath
+  }
+}
+
+function ShowError({ error }: { error: FrameError }): JSX.Element {
+  return (
+    <div
+      role="alert"
+      style={{ border: '1px solid #ececec', borderRadius: '5px' }}
+    >
+      <pre style={{ color: '#777', margin: 0 }}>
+        {error.componentName}({error.configPath})
+      </pre>
+      <div style={{ padding: '5px' }}>
+        <pre style={{ color: 'red', textAlign: 'center' }}>{error.message}</pre>
+      </div>
+    </div>
+  )
+}
+
 export function Frame(props: FrameContext): React.JSX.Element {
   const {
     frame: { view, data, frames },
@@ -24,36 +51,47 @@ export function Frame(props: FrameContext): React.JSX.Element {
     configPath,
   } = props
   const { component, props: viewProps } = view
-  const Component = getComponent(component, COMPONENTS)
-  const processedProps = processProps({ data, config, viewProps, COMPONENTS })
-  if (frames === undefined) {
-    if (data) {
-      return <DataProvider {...processedProps} component={Component} />
-    } else {
-      return <Component {...processedProps} />
+  try {
+    const Component = getComponent(component, configPath, COMPONENTS)
+    const processedProps = processProps({
+      data,
+      config,
+      configPath,
+      viewProps,
+      COMPONENTS,
+    })
+    if (frames === undefined) {
+      return data ? (
+        <DataProvider {...processedProps} component={Component} />
+      ) : (
+        <Component {...processedProps} />
+      )
     }
-  }
 
-  return (
-    <Component {...props}>
-      {frames.map((subframe, k) => {
-        const subframePath = `${configPath}.frames.${k}`
-        return (
-          <FrameWrapper key={k} frame={subframe} configPath={subframePath}>
-            <Frame
-              frame={subframe}
-              configPath={subframePath}
-              globalContext={props.globalContext}
-            />
-          </FrameWrapper>
-        )
-      })}
-    </Component>
-  )
+    return (
+      <Component {...props}>
+        {frames.map((subframe, k) => {
+          const subframePath = `${configPath}.frames.${k}`
+          return (
+            <FrameWrapper key={k} frame={subframe} configPath={subframePath}>
+              <Frame
+                frame={subframe}
+                configPath={subframePath}
+                globalContext={props.globalContext}
+              />
+            </FrameWrapper>
+          )
+        })}
+      </Component>
+    )
+  } catch (e: any) {
+    return <ShowError error={e} />
+  }
 }
 
 interface ComponentPropsShape {
   config: WorkflowV1
+  configPath: string
   viewProps: ViewPropsV1
   data: DataV1
   COMPONENTS: COMPONENTS
@@ -70,6 +108,7 @@ function isComponent(prop: YamlType): prop is string {
 
 function processProps({
   config,
+  configPath,
   viewProps,
   data,
   COMPONENTS,
@@ -79,7 +118,7 @@ function processProps({
     for (const propName in viewProps) {
       const prop = viewProps[propName]
       if (isComponent(prop)) {
-        newProps[propName] = getComponent(prop, COMPONENTS)
+        newProps[propName] = getComponent(prop, configPath, COMPONENTS)
       }
     }
   }
@@ -94,12 +133,17 @@ function processProps({
 
 export function getComponent(
   component: string,
+  configPath: string,
   COMPONENTS: COMPONENTS,
 ): OpenTrussComponent {
   const componentName = component.replaceAll(/(<|\/>)/g, '').trim()
   let Component = COMPONENTS[componentName]
   if (!Component) {
-    throw new Error(`No component '${componentName}' configured.`)
+    throw new FrameError(
+      `No component '${componentName}' configured.`,
+      componentName,
+      configPath,
+    )
   }
 
   if (hasDefaultExport(Component)) {
@@ -107,7 +151,11 @@ export function getComponent(
   }
 
   if (!Component) {
-    throw new Error(`No component '${componentName}' configured.`)
+    throw new FrameError(
+      `No component '${componentName}' configured.`,
+      componentName,
+      configPath,
+    )
   }
 
   return Component

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -61,11 +61,11 @@ export function Frame(props: FrameContext): React.JSX.Element {
       COMPONENTS,
     })
     if (frames === undefined) {
-      return data ? (
-        <DataProvider {...processedProps} component={Component} />
-      ) : (
-        <Component {...processedProps} />
-      )
+      if (data) {
+        return <DataProvider {...processedProps} component={Component} />
+      } else {
+        return <Component {...processedProps} />
+      }
     }
 
     return (

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -22,25 +22,32 @@ const OTDefaultFrameWrapper: FrameWrapper = ({ children }) => <>{children}</>
 
 export function RenderConfig({
   COMPONENTS,
-  config,
+  config: _config,
+  validateConfig = true,
 }: {
   COMPONENTS: COMPONENTS
   config: WorkflowV1
+  validateConfig?: boolean
 }): React.JSX.Element {
   _COMPONENTS = COMPONENTS
   // Runs validations in config-schemas
-  const result = WorkflowV1Shape.safeParse(config)
-  if (!result.success) {
-    // TODO for now just raise any config validation errors.
-    // We likely want to render something nicer eventually.
-    throw result.error
+  let config = _config
+  if (validateConfig) {
+    const result = WorkflowV1Shape.safeParse(config)
+    if (!result.success) {
+      // TODO for now just raise any config validation errors.
+      // We likely want to render something nicer eventually.
+      throw result.error
+    }
+    config = result.data
   }
   const FrameWrapper = getComponent(
     config.frameWrapper ?? 'OTDefaultFrameWrapper',
+    'workflow',
     { ...COMPONENTS, OTDefaultFrameWrapper },
   )
   const globalContext: GlobalContext = {
-    config: result.data,
+    config,
     COMPONENTS,
     FrameWrapper,
   }

--- a/packages/open-truss/src/pages/config-builder-page/index.tsx
+++ b/packages/open-truss/src/pages/config-builder-page/index.tsx
@@ -102,6 +102,7 @@ function Output({ components }: ConfigBuilderPageInterface): React.JSX.Element {
         <RenderConfig
           config={config}
           components={{ ...components, ConfigBuilderFrameWrapper }}
+          validateConfig={false}
         />
       )}
     </>


### PR DESCRIPTION
Closes https://github.com/open-truss/open-truss/issues/103.

While building a config, having the page break totally when you misconfigure something is an unpleasant experience. I've taught `<Frame />` to catch errors related to failing to find a component and render a UI saying what's up:

<img width="486" alt="image" src="https://github.com/open-truss/open-truss/assets/3272924/8f358957-d5ed-475a-9d93-e3c1f684cdab">

This could be where we do other frame-level config validations, like prop validation.