### PR TITLE
Add more validations for props

### DIFF
--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -85,7 +85,7 @@ export function getComponent(
   component: string,
   COMPONENTS: COMPONENTS,
 ): OpenTrussComponent {
-  const componentName = component.replaceAll(/(<|\/>)/g, '').trim()
+  const componentName = parseComponentName(component)
   let Component = COMPONENTS[componentName]
   if (!Component) {
     throw new Error(`No component '${componentName}' configured.`)
@@ -100,4 +100,8 @@ export function getComponent(
   }
 
   return Component
+}
+
+export function parseComponentName(componentName: string): string {
+  return componentName.replaceAll(/(<|\/>)/g, '').trim()
 }

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -2,6 +2,9 @@ import { z } from 'zod'
 import { YamlShape } from '../../utils/yaml'
 import { type OpenTrussComponentExports } from '../RenderConfig'
 import { RUNTIME_COMPONENTS } from './RenderConfig'
+import { parseComponentName } from './Frame'
+import { describeZod } from '../../utils/descibe-zod'
+import { type ZodDescriptionObject } from '../../utils/descibe-zod'
 
 // Data Schemas
 /*
@@ -28,6 +31,47 @@ workflow:
 const ViewPropsV1Shape = z.record(z.string(), YamlShape).optional()
 export type ViewPropsV1 = z.infer<typeof ViewPropsV1Shape>
 
+const ViewV1Shape = z
+  .object({
+    component: z.string(),
+    props: ViewPropsV1Shape,
+  })
+  .superRefine((view, ctx) => {
+    const COMPONENTS = RUNTIME_COMPONENTS()
+    const componentName = view.component
+    const Component = COMPONENTS[componentName]
+
+    if (Component === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Did not find ${componentName}`,
+        fatal: true,
+      })
+      return z.NEVER
+    }
+
+    if (view.props && hasPropsExport(Component)) {
+      const expectedComponentProps = describeZod(Component.Props.shape)
+      Object.entries(view.props).forEach(([propName, propValue]) => {
+        const expectedProp = expectedComponentProps[propName]
+        if (expectedProp === undefined) {
+          // TODO probably fine to allow props not declared by the component?
+          return
+        }
+
+        const errors = isPropValueValid(expectedProp, propValue)
+        if (errors.length > 0) {
+          const e = errors.join(',')
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${propName} does not match type expected by ${componentName}. Errors: ${e}`,
+            fatal: true,
+          })
+        }
+      })
+    }
+  })
+
 // Frame Schemas
 /*
 workflow:
@@ -37,10 +81,7 @@ workflow:
 
 const FrameBase = z.object({
   frame: z.null(), // used only to make configs more readable
-  view: z.object({
-    component: z.string(),
-    props: ViewPropsV1Shape,
-  }),
+  view: ViewV1Shape,
   data: DataV1Shape,
 })
 
@@ -131,4 +172,108 @@ export function hasChildren(
   }
   // Default to true for legacy component definitions
   return true
+}
+
+function isPropValueValid(
+  zodType: ZodDescriptionObject,
+  propValue: z.infer<typeof YamlShape>,
+): string[] {
+  const errors: string[] = []
+
+  switch (zodType.type) {
+    case 'ZodUndefined':
+      break
+    case 'ZodNull':
+      break
+    case 'ZodVoid':
+      break
+    case 'ZodObject': {
+      // Is there another way to check if something is an object???
+      // Javascript is mad
+      if (
+        typeof propValue !== 'object' ||
+        propValue === null ||
+        Array.isArray(propValue) ||
+        typeof propValue === 'function'
+      ) {
+        errors.push(`Expected ${String(propValue)} to be a ZodObject`)
+        break
+      }
+
+      if (propValue.type === undefined) {
+        errors.push(`Expected ${String(propValue)} to have type property`)
+        break
+      }
+
+      // This is where we can support prop validation for complex types if we want
+      // e.g. Props that are components that the also have props
+      /*
+      workflow:
+        frames:
+          - frame:
+            view:
+              component: OTAvailableWorkflowsFromEndpoint
+              props:
+                link:
+                  type: component
+                  component <NextLink />
+                  props:
+                    defaultRedirect: "https://open-truss.dev"
+      */
+
+      break
+    }
+    case 'ZodArray':
+      if (!Array.isArray(propValue)) {
+        errors.push(`Expected ${String(propValue)} to be a ZodArray`)
+      }
+      break
+    case 'ZodNumber':
+      if (typeof propValue !== 'number') {
+        errors.push(`Expected ${String(propValue)} to be a ZodNumber`)
+      }
+      break
+    case 'ZodBigInt':
+    case 'ZodString':
+      if (typeof propValue !== 'string') {
+        errors.push(`Expected ${String(propValue)} to be a ZodString`)
+      }
+      break
+    case 'ZodBoolean':
+      if (typeof propValue !== 'boolean') {
+        errors.push(`Expected ${String(propValue)} to be a ZodBoolean`)
+      }
+      break
+    case 'ZodEnum': {
+      const enums = zodType.shape
+      if (typeof propValue !== 'string') {
+        errors.push(`Expected ${String(propValue)} to be a ZodString`)
+        break
+      }
+      if (Array.isArray(enums) && !enums.includes(propValue)) {
+        const validEnums = enums.join(',')
+        errors.push(`${propValue} is not valid. Valid enums are ${validEnums}`)
+      }
+      break
+    }
+    case 'ZodOptional':
+      if (propValue !== undefined && zodType.shape !== undefined) {
+        errors.push(...isPropValueValid(zodType.shape, propValue))
+      }
+      break
+    case 'ZodFunction': {
+      const COMPONENTS = RUNTIME_COMPONENTS()
+      if (typeof propValue === 'string') {
+        const componentName = parseComponentName(propValue)
+        if (COMPONENTS[componentName] === undefined) {
+          errors.push(`Could not find component ${propValue}`)
+        }
+      }
+      break
+    }
+    default:
+      throw new Error('Unknown Zod Description')
+  }
+
+  return errors
 }

--- a/packages/open-truss/src/utils/descibe-zod.test.ts
+++ b/packages/open-truss/src/utils/descibe-zod.test.ts
@@ -14,6 +14,7 @@ test('describeZod', () => {
     arrayProp: z.array(z.string()).default(['a', 'b', 'c']),
     enumProp: z.enum(['enum1', 'enum2']).default('enum1'),
     unionProp: z.union([z.number(), z.string()]).default(123),
+    optionalProp: z.string().optional(),
   })
   expect(describeZod(props.shape)).toEqual({
     stringProp: { type: 'ZodString', defaultValue: 'hello world' },
@@ -42,6 +43,12 @@ test('describeZod', () => {
       type: 'ZodUnion',
       shape: [{ type: 'ZodNumber' }, { type: 'ZodString' }],
       defaultValue: 123,
+    },
+    optionalProp: {
+      type: 'ZodOptional',
+      shape: {
+        type: 'ZodString',
+      },
     },
   })
 })

--- a/packages/open-truss/src/utils/descibe-zod.ts
+++ b/packages/open-truss/src/utils/descibe-zod.ts
@@ -2,10 +2,13 @@ import { type z } from 'zod'
 import { BaseOpenTrussComponentV1PropsShape } from '../configuration'
 import { type YamlType } from '../utils/yaml'
 
-type ZodShape = ZodDescriptionObject | string[]
+type ZodShape =
+  | ZodDescriptionObject
+  | Record<string, ZodDescriptionObject>
+  | string[]
 
 export interface ZodDescriptionObject {
-  type?: string
+  type: string
   defaultValue?: YamlType
   shape?: ZodShape
 }
@@ -41,6 +44,7 @@ export function describeZod(
       } else if (type === 'ZodDefault') {
         const innerType = value._def.innerType
         const desc: ZodDescriptionObject = {
+          type: innerType,
           defaultValue: value._def.defaultValue(),
           ...(describeZod({ innerType }).innerType as object),
         }

--- a/packages/open-truss/src/utils/descibe-zod.ts
+++ b/packages/open-truss/src/utils/descibe-zod.ts
@@ -7,11 +7,34 @@ type ZodShape =
   | Record<string, ZodDescriptionObject>
   | string[]
 
-export interface ZodDescriptionObject {
-  type: string
-  defaultValue?: YamlType
+interface BaseZodDescriptionObject {
+  defaultValue?: YamlType // Assuming YamlType is defined elsewhere
+}
+
+// Specific description object types
+interface ZodObjectWithShape extends BaseZodDescriptionObject {
+  type:
+    | 'ZodEnum'
+    | 'ZodObject'
+    | 'ZodArray'
+    | 'ZodUnion'
+    | 'ZodFunction'
+    | 'ZodNumber'
+    | 'ZodBigInt'
+    | 'ZodString'
+    | 'ZodBoolean'
+    | 'ZodNull'
+    | 'ZodUndefined'
+    | 'ZodVoid'
   shape?: ZodShape
 }
+
+interface ZodObjectWithDescription extends BaseZodDescriptionObject {
+  type: 'ZodOptional'
+  shape: ZodDescriptionObject
+}
+
+export type ZodDescriptionObject = ZodObjectWithDescription | ZodObjectWithShape
 
 // describeZod outputs a readable summary of a zod type.
 // In Open Truss we use this to describe a component's prop types
@@ -40,6 +63,11 @@ export function describeZod(
           shape: value._def.options.map((innerType: z.ZodType) => {
             return describeZod({ innerType }).innerType
           }),
+        }
+      } else if (type === 'ZodOptional') {
+        description[key] = {
+          type,
+          shape: describeZod({ innerType: value.unwrap() }).innerType,
         }
       } else if (type === 'ZodDefault') {
         const innerType = value._def.innerType


### PR DESCRIPTION
resolves https://github.com/open-truss/open-truss/issues/105

## Why

We want more prop level validations to ensure configs are valid

## How

This PR does a little bit of refactoring, but the bulk of it adds more validations. Notably the following View-level validations:
  - validate component declared in the config exists
  - validate props match what component expects
    - validate scalars are the correct type
    - validate components passed as props exist
    - validate enums and ensure value passed in is valid

This should be relatively straightforward to review. You can review this commit by commit or by reading through the changes in the config-schemas file and jumping to refactors that support the changes.