### PR TITLE
Refactor types to make them more descriptive

### DIFF
--- a/demo-app/src/open-truss/components/ClientPageTitle.tsx
+++ b/demo-app/src/open-truss/components/ClientPageTitle.tsx
@@ -1,4 +1,7 @@
-import { BaseOpenTrussComponentV1PropsShape } from '@open-truss/open-truss'
+import {
+  type BaseOpenTrussComponentV1,
+  BaseOpenTrussComponentV1PropsShape,
+} from '@open-truss/open-truss'
 import { z } from 'zod'
 
 export const Props = BaseOpenTrussComponentV1PropsShape.extend({
@@ -7,11 +10,11 @@ export const Props = BaseOpenTrussComponentV1PropsShape.extend({
   title: z.string().default('Page Title'),
 })
 
-function PageTitle({
+const ClientPageTitle: BaseOpenTrussComponentV1<typeof Props> = ({
   color,
   headerElement = 'h1',
   title,
-}: z.infer<typeof Props>): JSX.Element {
+}) => {
   const Component = headerElement
   return (
     <Component style={{ color }}>
@@ -20,4 +23,4 @@ function PageTitle({
   )
 }
 
-export default PageTitle
+export default ClientPageTitle

--- a/demo-app/src/open-truss/components/NextLink.tsx
+++ b/demo-app/src/open-truss/components/NextLink.tsx
@@ -1,16 +1,20 @@
 import {
   withChildren,
+  type BaseOpenTrussComponentV1,
   BaseOpenTrussComponentV1PropsShape,
 } from '@open-truss/open-truss'
 import Link from 'next/link'
 import { z } from 'zod'
 
-export const Props = withChildren(BaseOpenTrussComponentV1PropsShape).extend({
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
   to: z.string(),
 })
 
-export default function NextLink(props: z.infer<typeof Props>): JSX.Element {
+const NextLink: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (props) => {
   // z.string is type string | undefined and Link doesn't like that
   // need to figure out how to get zod to not have types with undefined
   return <Link href={props.to || '/'}>{props.children}</Link>
 }
+
+export default NextLink

--- a/demo-app/src/open-truss/components/TrinoDemo.tsx
+++ b/demo-app/src/open-truss/components/TrinoDemo.tsx
@@ -1,16 +1,20 @@
 'use client'
 import {
+  type BaseOpenTrussComponentV1,
   BaseOpenTrussComponentV1PropsShape,
   withChildren,
 } from '@open-truss/open-truss'
 import { z } from 'zod'
 
-export const Props = withChildren(BaseOpenTrussComponentV1PropsShape).extend({
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
   data: z.string().default('no data'),
 })
 
-export default function TrinoDemo({
+const TrinoDemo: BaseOpenTrussComponentV1<z.infer<typeof Props>> = ({
   data,
-}: z.infer<typeof Props>): JSX.Element {
+}) => {
   return <>{JSON.stringify(data)}</>
 }
+
+export default TrinoDemo

--- a/demo-app/src/open-truss/components/YourAppExampleComponent.tsx
+++ b/demo-app/src/open-truss/components/YourAppExampleComponent.tsx
@@ -1,17 +1,19 @@
 import {
   withChildren,
+  type BaseOpenTrussComponentV1,
   BaseOpenTrussComponentV1PropsShape,
 } from '@open-truss/open-truss'
 import { z } from 'zod'
 
-export const Props = withChildren(BaseOpenTrussComponentV1PropsShape).extend({
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
   count: z.number().default(123),
   iAmABoolProp: z.boolean().default(true),
 })
 
-export default function YourAppExampleComponent(
-  props: z.infer<typeof Props>,
-): JSX.Element {
+const YourAppExampleComponent: BaseOpenTrussComponentV1<
+  z.infer<typeof Props>
+> = (props) => {
   return (
     <div>
       <div>
@@ -23,3 +25,5 @@ export default function YourAppExampleComponent(
     </div>
   )
 }
+
+export default YourAppExampleComponent

--- a/packages/open-truss/src/components/OTAvailableWorkflowsFromEndpoint.tsx
+++ b/packages/open-truss/src/components/OTAvailableWorkflowsFromEndpoint.tsx
@@ -2,17 +2,19 @@ import React from 'react'
 import {
   withChildren,
   BaseOpenTrussComponentV1PropsShape,
+  type BaseOpenTrussComponentV1,
 } from '../configuration/engine-v1'
 import { CSLinkShape } from '../shims'
 import { type z } from 'zod'
 
-export const Props = withChildren(BaseOpenTrussComponentV1PropsShape).extend({
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
   link: CSLinkShape,
 })
 
-export default function AvailableWorkflowsFromEndpoint(
-  props: z.infer<typeof Props>,
-): JSX.Element {
+const AvailableWorkflowsFromEndpoint: BaseOpenTrussComponentV1<
+  z.infer<typeof Props>
+> = (props) => {
   const [workflowIds, setConfigs] = React.useState<string[]>([])
   const [loading, setLoading] = React.useState<boolean>(false)
   const [error, setError] = React.useState<Error | null>(null)
@@ -53,3 +55,5 @@ export default function AvailableWorkflowsFromEndpoint(
     </div>
   )
 }
+
+export default AvailableWorkflowsFromEndpoint

--- a/packages/open-truss/src/components/OTExampleComponent.tsx
+++ b/packages/open-truss/src/components/OTExampleComponent.tsx
@@ -1,11 +1,11 @@
-import { type BaseOpenTrussComponentV1Props } from '@/configuration'
+import { type BaseOpenTrussComponentV1 } from '@/configuration'
 
-export default function OTExampleComponent(
-  props: BaseOpenTrussComponentV1Props,
-): JSX.Element {
+const OTExampleComponent: BaseOpenTrussComponentV1 = (props) => {
   return (
     <div>
       This component is from OT. It is called <b>OTExampleComponent</b>.
     </div>
   )
 }
+
+export default OTExampleComponent

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -29,7 +29,7 @@ export function RenderConfig({
   config: WorkflowV1
   validateConfig?: boolean
 }): React.JSX.Element {
-  _COMPONENTS = COMPONENTS
+  _COMPONENTS = Object.assign(COMPONENTS, { OTDefaultFrameWrapper })
   // Runs validations in config-schemas
   let config = _config
   if (validateConfig) {
@@ -44,8 +44,8 @@ export function RenderConfig({
   const FrameWrapper = getComponent(
     config.frameWrapper ?? 'OTDefaultFrameWrapper',
     'workflow',
-    { ...COMPONENTS, OTDefaultFrameWrapper },
-  )
+    COMPONENTS,
+  ) as FrameWrapper
   const globalContext: GlobalContext = {
     config,
     COMPONENTS,

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -95,32 +95,33 @@ export type WorkflowV1 = z.infer<typeof WorkflowV1Shape>
 
 export const BaseOpenTrussComponentV1PropsShape = z.object({
   data: DataV1Shape,
-  config: WorkflowV1Shape,
+  config: WorkflowV1Shape.optional(),
 })
-export const withChildren = (shape: z.AnyZodObject): z.AnyZodObject =>
-  shape.extend({ children: z.any().optional() })
-const ComponentWithChildrenShape = withChildren(
-  BaseOpenTrussComponentV1PropsShape,
-)
+
+export const withChildren = { children: z.any().optional() }
+const ComponentWithChildrenShape =
+  BaseOpenTrussComponentV1PropsShape.extend(withChildren)
 type ComponentWithChildren = z.infer<typeof ComponentWithChildrenShape>
 
-export type BaseOpenTrussComponentV1Props =
-  | z.infer<typeof BaseOpenTrussComponentV1PropsShape>
-  | ComponentWithChildren
-
-export type BaseOpenTrussComponentV1 = (
-  props: BaseOpenTrussComponentV1Props,
-) => React.JSX.Element
-
-const FrameWrapperShape = withChildren(
-  BaseOpenTrussComponentV1PropsShape,
-).extend({
+const FrameWrapperShape = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
   configPath: z.string(),
   frame: FrameV1Shape,
 })
-export type FrameWrapper = (
-  props: z.infer<typeof FrameWrapperShape>,
+
+type BaseOpenTrussComponentV1Props = z.infer<
+  typeof BaseOpenTrussComponentV1PropsShape
+>
+
+export type BaseOpenTrussComponentV1<
+  AdditionalProps = Record<string, unknown>,
+> = (
+  props: BaseOpenTrussComponentV1Props & AdditionalProps,
 ) => React.JSX.Element
+
+export type FrameWrapper = BaseOpenTrussComponentV1<
+  z.infer<typeof FrameWrapperShape>
+>
 
 export function hasDefaultExport(
   component: any,

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -98,6 +98,16 @@ export const BaseOpenTrussComponentV1PropsShape = z.object({
   config: WorkflowV1Shape.optional(),
 })
 
+type BaseOpenTrussComponentV1Props = z.infer<
+  typeof BaseOpenTrussComponentV1PropsShape
+>
+
+export type BaseOpenTrussComponentV1<
+  AdditionalProps = Record<string, unknown>,
+> = (
+  props: BaseOpenTrussComponentV1Props & AdditionalProps,
+) => React.JSX.Element
+
 export const withChildren = { children: z.any().optional() }
 const ComponentWithChildrenShape =
   BaseOpenTrussComponentV1PropsShape.extend(withChildren)
@@ -108,16 +118,6 @@ const FrameWrapperShape = BaseOpenTrussComponentV1PropsShape.extend({
   configPath: z.string(),
   frame: FrameV1Shape,
 })
-
-type BaseOpenTrussComponentV1Props = z.infer<
-  typeof BaseOpenTrussComponentV1PropsShape
->
-
-export type BaseOpenTrussComponentV1<
-  AdditionalProps = Record<string, unknown>,
-> = (
-  props: BaseOpenTrussComponentV1Props & AdditionalProps,
-) => React.JSX.Element
 
 export type FrameWrapper = BaseOpenTrussComponentV1<
   z.infer<typeof FrameWrapperShape>

--- a/packages/open-truss/src/configuration/engine-v1/index.ts
+++ b/packages/open-truss/src/configuration/engine-v1/index.ts
@@ -9,5 +9,4 @@ export {
   type BaseOpenTrussComponentV1,
   type FrameType,
   type FrameWrapper,
-  type BaseOpenTrussComponentV1Props,
 } from './config-schemas'

--- a/packages/open-truss/src/pages/config-builder-page/index.tsx
+++ b/packages/open-truss/src/pages/config-builder-page/index.tsx
@@ -101,7 +101,7 @@ function Output({ components }: ConfigBuilderPageInterface): React.JSX.Element {
       {!showConfig && (
         <RenderConfig
           config={config}
-          components={{ ...components, ConfigBuilderFrameWrapper }}
+          components={Object.assign(components, { ConfigBuilderFrameWrapper })}
           validateConfig={false}
         />
       )}


### PR DESCRIPTION
This PR does two main things:

1. `withChildren` is just an object now. The function way was throwing away types and after refactoring it to not do this I realized that I think this is more ergonomic.
2. `BaseOpenTrussComponentV1` is now a generic type that can be used to declare components. I think this is nice as we don't need to type every component as returning JSX.Element.

**Before**
<img width="537" alt="image" src="https://github.com/open-truss/open-truss/assets/3272924/5c17d0a7-6c9e-4633-9beb-1050853978be">


**After**
<img width="804" alt="image" src="https://github.com/open-truss/open-truss/assets/3272924/c0ff9432-ec86-4ccc-95a9-4d6fcb0e59c9">
