### PR TITLE
Fix render bug in config builder

### DIFF
--- a/demo-app/src/pages/ot/config-builder/PropInput.tsx
+++ b/demo-app/src/pages/ot/config-builder/PropInput.tsx
@@ -1,6 +1,8 @@
+import {
+  type YamlType,
+  type ZodDescriptionObject,
+} from '@open-truss/open-truss'
 import { useEffect } from 'react'
-import { type YamlType } from '../../utils/yaml'
-import { type ZodDescriptionObject } from '../../utils/descibe-zod'
 
 export default function PropInput({
   name,

--- a/demo-app/src/pages/ot/config-builder/PropInput.tsx
+++ b/demo-app/src/pages/ot/config-builder/PropInput.tsx
@@ -18,7 +18,7 @@ export default function PropInput({
 
   useEffect(() => {
     onChange(defaultValue)
-  }, [defaultValue])
+  }, [])
 
   if (name === 'children') {
     return null


### PR DESCRIPTION
1. Not really sure how to fix the infinite render loop so I just made this change for now: 783245204e99b140a00d5c8d5c8fc6fc27c01dc5
2. These imports should come from open-truss and not the demo-app: cca6a9f32fdfeae738423f8a35546753889b4fc3

Still one outstanding bug afaict related to signals:

![CleanShot 2024-02-26 at 10 23 31@2x](https://github.com/open-truss/open-truss/assets/623/147f362a-cecc-4495-890d-64a904829ac6)

App go boom 💥 

![CleanShot 2024-02-26 at 10 25 34@2x](https://github.com/open-truss/open-truss/assets/623/643ef803-cd94-48be-a639-61e652082859)
