### PR TITLE
Two small fixes for the config builder

### DIFF
--- a/demo-app/src/pages/ot/config-builder/index.tsx
+++ b/demo-app/src/pages/ot/config-builder/index.tsx
@@ -31,12 +31,9 @@ const Output: React.FC = () => {
       {!showConfig && (
         <RenderConfig
           config={config}
-          components={Object.assign(
-            { ...OT_COMPONENTS },
-            {
-              ConfigBuilderFrameWrapper,
-            },
-          )}
+          components={Object.assign({}, OT_COMPONENTS, {
+            ConfigBuilderFrameWrapper,
+          })}
           validateConfig={false}
         />
       )}

--- a/demo-app/src/pages/ot/config-builder/index.tsx
+++ b/demo-app/src/pages/ot/config-builder/index.tsx
@@ -31,9 +31,12 @@ const Output: React.FC = () => {
       {!showConfig && (
         <RenderConfig
           config={config}
-          components={Object.assign(OT_COMPONENTS, {
-            ConfigBuilderFrameWrapper,
-          })}
+          components={Object.assign(
+            { ...OT_COMPONENTS },
+            {
+              ConfigBuilderFrameWrapper,
+            },
+          )}
           validateConfig={false}
         />
       )}

--- a/packages/open-truss/src/configuration/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/RenderConfig.tsx
@@ -29,7 +29,7 @@ export function RenderConfig({
   config: string
   validateConfig?: boolean
 }): React.JSX.Element {
-  const components = Object.assign(appComponents, OT_COMPONENTS)
+  const components = Object.assign({ ...appComponents }, OT_COMPONENTS)
   const parsedConfig = parseYaml(config)
   const workflow = (parsedConfig as unknown as WorkflowSpec).workflow
   if (workflow.version === 1) {

--- a/packages/open-truss/src/configuration/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/RenderConfig.tsx
@@ -29,7 +29,7 @@ export function RenderConfig({
   config: string
   validateConfig?: boolean
 }): React.JSX.Element {
-  const components = Object.assign({ ...appComponents }, OT_COMPONENTS)
+  const components = Object.assign({}, appComponents, OT_COMPONENTS)
   const parsedConfig = parseYaml(config)
   const workflow = (parsedConfig as unknown as WorkflowSpec).workflow
   if (workflow.version === 1) {

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -35,7 +35,7 @@ export function RenderConfig({
   config: WorkflowV1
   validateConfig?: boolean
 }): React.JSX.Element {
-  _COMPONENTS = Object.assign(COMPONENTS, { OTDefaultFrameWrapper })
+  _COMPONENTS = Object.assign({ ...COMPONENTS }, { OTDefaultFrameWrapper })
   // Runs validations in config-schemas
   let config = _config
   if (validateConfig) {

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { type COMPONENTS } from '../RenderConfig'
 import {
   type FrameWrapper,
@@ -70,7 +70,7 @@ export function RenderConfig({
     FrameWrapper,
     workflowId,
   }
-  setWorkflowSession(workflowId)
+  useSetWorkflowSession(workflowId)
   // Workflows are just frames! Use unknown to convince TS of this fact.
   const frame = {
     ...config,
@@ -134,8 +134,10 @@ function validateComponentProps(
   return errors
 }
 
-function setWorkflowSession(id: string): void {
-  localStorage.setItem(`OT-Workflow:${id}`, JSON.stringify({}))
+function useSetWorkflowSession(id: string): void {
+  useEffect(() => {
+    localStorage.setItem(`OT-Workflow:${id}`, JSON.stringify({}))
+  }, [id])
 }
 
 export function getWorkflowSession(

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -19,9 +19,9 @@ export interface GlobalContext {
   workflowId: string
 }
 
-let _COMPONENTS: COMPONENTS
+let COMBINED_COMPONENTS: COMPONENTS
 export function RUNTIME_COMPONENTS(): COMPONENTS {
-  return _COMPONENTS
+  return COMBINED_COMPONENTS
 }
 
 const OTDefaultFrameWrapper: FrameWrapper = ({ children }) => <>{children}</>
@@ -35,7 +35,7 @@ export function RenderConfig({
   config: WorkflowV1
   validateConfig?: boolean
 }): React.JSX.Element {
-  _COMPONENTS = Object.assign({ ...COMPONENTS }, { OTDefaultFrameWrapper })
+  COMBINED_COMPONENTS = Object.assign({}, COMPONENTS, { OTDefaultFrameWrapper })
   // Runs validations in config-schemas
   let config = _config
   if (validateConfig) {
@@ -51,13 +51,17 @@ export function RenderConfig({
   const FrameWrapper = getComponent(
     config.frameWrapper ?? 'OTDefaultFrameWrapper',
     configPath,
-    COMPONENTS,
+    COMBINED_COMPONENTS,
   ) as FrameWrapper
 
   const signals = createSignals(config.signals, validateConfig)
 
   if (validateConfig) {
-    const propErrs = validateComponentProps(config.frames, COMPONENTS, signals)
+    const propErrs = validateComponentProps(
+      config.frames,
+      COMBINED_COMPONENTS,
+      signals,
+    )
     if (propErrs.length > 0) {
       console.log(`Encountered component prop errors: ${propErrs.join(',')}`)
     }
@@ -66,7 +70,7 @@ export function RenderConfig({
   const globalContext: GlobalContext = {
     signals,
     config,
-    COMPONENTS,
+    COMPONENTS: COMBINED_COMPONENTS,
     FrameWrapper,
     workflowId,
   }


### PR DESCRIPTION
### 1. `localStorage` is not defined on the server

@jonmagic pointed out that the config builder was having trouble accessing `localStorage`. The demo app is NextJS which always tries to server render things. `localStorage` isn't on the server so this broke the config builder, which is able to rendered on the server. This didn't affect config playground pages because the `RenderConfig` calls are done in the client just by the fact that we fetch the config on page load using an API.

### 2. Server rendering and client rendering got different results

This was because I was using `Object.assign` to merge the demo app's components with OT's components. `Object.assign` [mutates the target object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) which led to weird behavior. I fixed it by duplicating the object within the assign. I also fixed all cases of this even though they weren't causing issues right now as they could have caused subtle bugs.