### PR TITLE
Add --sync option to packages/open-truss/bin/tsc-watch and use in script/server

### DIFF
--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "tsc:sync": "open-truss tsc-watch --sync",
     "tsc:watch": "open-truss tsc-watch",
     "ot:setup": "open-truss setup",
     "build": "next build",

--- a/demo-app/script/server
+++ b/demo-app/script/server
@@ -12,6 +12,8 @@ cd $open_truss_package_dir \
   && rm -r dist/ \
   && cd $demo_app_dir
 
+npm run tsc:sync
+
 # Function to terminate both tsc processes
 terminate_tsc_processes() {
   echo "Terminating TypeScript watch processes..."

--- a/packages/open-truss/bin/tsc-watch
+++ b/packages/open-truss/bin/tsc-watch
@@ -6,6 +6,12 @@ cd $package_dir
 
 PACKAGE_DIR=$package_dir bin/append-package-json-to-dist
 
+if [ "$1" == "--sync" ]; then
+  tsc --project $PACKAGE_DIR/tsconfig.json
+  tsc --project $PACKAGE_DIR/tsconfig.esm.json
+  exit
+fi
+
 # Function to terminate both tsc processes
 terminate_tsc_processes() {
   echo "Terminating TypeScript watch processes..."


### PR DESCRIPTION
## Why?

We're seeing some time related issues when running script/server that causes the editor and builds to throw errors sometimes but not all of the time.

## How?

Synchronously compile at the beginning of script/server before starting the asynchronous builds.