### PR TITLE
First pass at data provider component

### DIFF
--- a/demo-app/src/open-truss/components/IntegerInput.tsx
+++ b/demo-app/src/open-truss/components/IntegerInput.tsx
@@ -1,8 +1,8 @@
 import {
   BaseOpenTrussComponentV1PropsShape,
   NavigateFrameSignal,
+  NumberSignal,
 } from '@open-truss/open-truss'
-import { NumberSignal } from '../signals'
 import { type z } from 'zod'
 import { useState } from 'react'
 

--- a/demo-app/src/open-truss/components/ShowIntegerSquared.tsx
+++ b/demo-app/src/open-truss/components/ShowIntegerSquared.tsx
@@ -1,8 +1,8 @@
 import {
   BaseOpenTrussComponentV1PropsShape,
   computed,
+  NumberSignal,
 } from '@open-truss/open-truss'
-import { NumberSignal } from '../signals'
 import { type z } from 'zod'
 
 export const Props = BaseOpenTrussComponentV1PropsShape.extend({

--- a/demo-app/src/open-truss/components/TrinoDemo.tsx
+++ b/demo-app/src/open-truss/components/TrinoDemo.tsx
@@ -3,18 +3,19 @@ import {
   type BaseOpenTrussComponentV1,
   BaseOpenTrussComponentV1PropsShape,
   withChildren,
+  RecordsSignal,
 } from '@open-truss/open-truss'
-import { z } from 'zod'
+import { type z } from 'zod'
 
 export const Props = BaseOpenTrussComponentV1PropsShape.extend({
   ...withChildren,
-  data: z.string().default('no data'),
+  results: RecordsSignal,
 })
 
 const TrinoDemo: BaseOpenTrussComponentV1<z.infer<typeof Props>> = ({
-  data,
+  results,
 }) => {
-  return <>{JSON.stringify(data)}</>
+  return <>{JSON.stringify(results)}</>
 }
 
 export default TrinoDemo

--- a/demo-app/src/open-truss/configs/4-trino-demo.yaml
+++ b/demo-app/src/open-truss/configs/4-trino-demo.yaml
@@ -1,9 +1,113 @@
 workflow:
   version: 1
+  signals:
+    results: Records
   frames:
     - frame:
-      data:
-        query: select * from  tpch.sf1.customer limit 10
-        source: trino-demo
+      # signals:
+      #   results: Records
       view:
-        component: TrinoDemo
+        component: UqiDataProvider
+        props:
+          source: trino-demo
+          query: >
+            SELECT Column
+            FROM tpch.sf1.customer
+            limit 10
+          results: :results
+        # TODO modify workflow where you select the type
+        # and it gets set as a param here
+        # params:
+        #   type:
+        # pageSize: 50
+          output:
+            results:
+              - column: string
+                # Type: string
+                # Extra: string
+                # Comment: string
+            # results2:
+            #   key: string
+            #   type: string
+            #   value: string
+      frames:
+        - frame:
+          view:
+            component: TrinoDemo
+            props:
+              results: :results # TrinoDemo takes a colleciton type
+
+workflow:
+  version: 1
+  signals:
+    results: Records
+  frames:
+    - frame:
+      view:
+        component: UqiDataProvider
+        props:
+          source: trino-demo
+          query: >
+            SELECT Column
+            FROM tpch.sf1.customer
+            limit 10
+          results: :results
+          output:
+            results:
+              - Column: string
+                Type: string
+                Extra: string
+                Comment: string
+      frames:
+        - frame:
+          view:
+            component: TrinoDemo
+            props:
+              results: :results
+
+
+
+
+
+
+
+
+
+
+
+
+# workflow:
+#   version: 1
+#   signals:
+#     results: Records
+#   frames:
+#     - frame:
+#       data:
+#         query: >\n
+#           SELECT key, type, value
+#           FROM tpch.sf1.customer
+#           WHERE type = 'BigInt'
+#         source: trino-demo
+#         output:
+#           results:
+#             - key: string
+#               type: string
+#               value: string
+#       view:
+#         component: TrinoDemo
+#         props:
+#           results: :results # TrinoDemo takes a colleciton type
+# TODO
+# - [x] update trino demo component to take in results
+# - [ ] update data provider to support outputs
+#   - [x] sketched out config
+#   - [ ] update data provider to loop through output config and create signals for each property
+#   - [ ] grab data from the results and put them into the signals
+# - [ ] update data provider to support params (sequence demo_
+# - [ ] update data provider to support pagination
+# - [ ] update data provider to support isLoading
+# - [ ] update signals to have one at every frame level
+# - [ ] refactor component to OT package
+# - [ ] update UqiDataprovider type mapping to support user defined higher order signal types
+# - [ ] update UqiDataprovider to support annotgations that are scalar results and not just arrays of objects or objects
+# - [ ] update UqiDataprovider to only pass through results that the config has declared and not excess results returned by uqi.

--- a/demo-app/src/open-truss/configs/4-trino-demo.yaml
+++ b/demo-app/src/open-truss/configs/4-trino-demo.yaml
@@ -5,7 +5,7 @@ workflow:
   frames:
     - frame:
       view:
-        component: UqiDataProvider
+        component: OTUqiDataProvider
         props:
           source: trino-demo
           query: >

--- a/demo-app/src/open-truss/configs/4-trino-demo.yaml
+++ b/demo-app/src/open-truss/configs/4-trino-demo.yaml
@@ -4,51 +4,12 @@ workflow:
     results: Records
   frames:
     - frame:
-      # signals:
-      #   results: Records
       view:
         component: UqiDataProvider
         props:
           source: trino-demo
           query: >
-            SELECT Column
-            FROM tpch.sf1.customer
-            limit 10
-          results: :results
-        # TODO modify workflow where you select the type
-        # and it gets set as a param here
-        # params:
-        #   type:
-        # pageSize: 50
-          output:
-            results:
-              - column: string
-                # Type: string
-                # Extra: string
-                # Comment: string
-            # results2:
-            #   key: string
-            #   type: string
-            #   value: string
-      frames:
-        - frame:
-          view:
-            component: TrinoDemo
-            props:
-              results: :results # TrinoDemo takes a colleciton type
-
-workflow:
-  version: 1
-  signals:
-    results: Records
-  frames:
-    - frame:
-      view:
-        component: UqiDataProvider
-        props:
-          source: trino-demo
-          query: >
-            SELECT Column
+            SELECT 'Column', 'Type', 'Extra', 'Comment'
             FROM tpch.sf1.customer
             limit 10
           results: :results
@@ -63,51 +24,4 @@ workflow:
           view:
             component: TrinoDemo
             props:
-              results: :results
-
-
-
-
-
-
-
-
-
-
-
-
-# workflow:
-#   version: 1
-#   signals:
-#     results: Records
-#   frames:
-#     - frame:
-#       data:
-#         query: >\n
-#           SELECT key, type, value
-#           FROM tpch.sf1.customer
-#           WHERE type = 'BigInt'
-#         source: trino-demo
-#         output:
-#           results:
-#             - key: string
-#               type: string
-#               value: string
-#       view:
-#         component: TrinoDemo
-#         props:
-#           results: :results # TrinoDemo takes a colleciton type
-# TODO
-# - [x] update trino demo component to take in results
-# - [ ] update data provider to support outputs
-#   - [x] sketched out config
-#   - [ ] update data provider to loop through output config and create signals for each property
-#   - [ ] grab data from the results and put them into the signals
-# - [ ] update data provider to support params (sequence demo_
-# - [ ] update data provider to support pagination
-# - [ ] update data provider to support isLoading
-# - [ ] update signals to have one at every frame level
-# - [ ] refactor component to OT package
-# - [ ] update UqiDataprovider type mapping to support user defined higher order signal types
-# - [ ] update UqiDataprovider to support annotgations that are scalar results and not just arrays of objects or objects
-# - [ ] update UqiDataprovider to only pass through results that the config has declared and not excess results returned by uqi.
+              results: :results # TrinoDemo takes a colleciton type

--- a/demo-app/src/open-truss/configs/4-trino-demo.yaml
+++ b/demo-app/src/open-truss/configs/4-trino-demo.yaml
@@ -9,16 +9,16 @@ workflow:
         props:
           source: trino-demo
           query: >
-            SELECT 'Column', 'Type', 'Extra', 'Comment'
+            SELECT name, phone, acctbal, comment
             FROM tpch.sf1.customer
             limit 10
           results: :results
           output:
             results:
-              - Column: string
-                Type: string
-                Extra: string
-                Comment: string
+              - name: string
+                phone: string
+                acctbal: number
+                comment: string
       frames:
         - frame:
           view:

--- a/demo-app/src/open-truss/signals.ts
+++ b/demo-app/src/open-truss/signals.ts
@@ -1,12 +1,5 @@
 import { SignalType } from '@open-truss/open-truss'
 
 // scalar types
-export const NumbersSignal = SignalType<number[]>('number[]', [])
-export const NumberSignal = SignalType<number>('number', 0)
-export const StringsSignal = SignalType<string[]>('string[]', [])
-export const StringSignal = SignalType<string>('string', '')
-export const BooleansSignal = SignalType<boolean[]>('boolean[]', [])
-export const BooleanSignal = SignalType<boolean>('boolean', false)
-
 // higher order types
 export const AccountIDsSignal = SignalType<number[]>('AccountIDs', [])

--- a/packages/open-truss/src/components/OTUqiDataProvider.tsx
+++ b/packages/open-truss/src/components/OTUqiDataProvider.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import {
+  withChildren,
+  BaseOpenTrussComponentV1PropsShape,
+  type BaseOpenTrussComponentV1,
+} from '../configuration/engine-v1'
+import { type UqiColumn } from '../uqi/uqi'
+import { type Signal, StringSignal } from '../signals'
+import { z } from 'zod'
+
+interface SynchronousQueryResult {
+  rows: SynchronousQueryRow[]
+  metadata: SynchronousQueryMetadata
+}
+
+interface SynchronousQueryRow {
+  values: SynchronousQueryValue[]
+}
+
+interface SynchronousQueryValue {
+  key: string
+  type: string
+  value: string
+}
+
+interface SynchronousQueryMetadata {
+  columns: SynchronousQueryColumn[]
+}
+
+interface SynchronousQueryColumn {
+  name: string
+  type: string
+}
+
+export const Props = BaseOpenTrussComponentV1PropsShape.extend({
+  ...withChildren,
+  source: StringSignal,
+  query: StringSignal,
+  output: z.record(
+    z.union([z.record(z.string()), z.array(z.record(z.string()))]),
+  ),
+})
+
+const UqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
+  props,
+) => {
+  const { query, children, output, source } = props
+  const [queryResults, setQueryResults] =
+    React.useState<SynchronousQueryResult>()
+
+  React.useEffect(() => {
+    const fetchData = async function (): Promise<undefined> {
+      const result = await fetch('/api/synchronous-uqi-query', {
+        method: 'POST',
+        body: JSON.stringify({ query, source }),
+      })
+      const deserialized = await result.json()
+      setQueryResults(deserialized)
+    }
+
+    fetchData().catch(console.error)
+  }, [])
+
+  if (queryResults === undefined) return <></>
+
+  Object.entries(output).forEach(([k, v]) => {
+    // TODO make sure signals code is putting in signals even if compoennt doesn't declare that as a property
+    const signal = (props as Record<string, any>)[k]
+    if (signal === undefined) {
+      // TODO figure out how we want to handle this
+      console.log('missing signal in data component')
+      return
+    }
+
+    signal as Signal
+
+    const shape = Array.isArray(v) ? v[0] : v
+
+    if (!isShapeValid(shape, queryResults.metadata.columns)) {
+      // TODO handle error better
+      console.log('shape of data from server does not match output of query')
+    }
+
+    const result = Array.isArray(v) ? queryResults.rows : queryResults.rows[0]
+    signal.value = result
+  })
+
+  return children
+}
+
+// validates if the data conforms to the shape provided.
+// shape - key is the name of the property and the value is the javascript type
+// data - json object with followig shape
+//  [
+//    { key: 'greeting',  type: 'String', value: 'hello' },
+//    { key: 'goodbye',  type: 'String', value: 'byebye' }
+//  ]
+//
+function isShapeValid(
+  shape: Record<string, string>,
+  metadata: UqiColumn[],
+): boolean {
+  // Define a mapping from the types in metadata to JavaScript's typeof values
+  const typeMap: Record<string, string> = {
+    String: 'string',
+    Number: 'number',
+    Boolean: 'boolean',
+    BigInt: 'bigint',
+    // Add more mappings as necessary
+  }
+
+  for (const item of metadata) {
+    // Use the typeMap to translate the type to its JavaScript typeof counterpart
+    const jsType = typeMap[item.type]
+    if (!jsType) {
+      console.error(`Unsupported type: ${item.type}`)
+      return false // Unsupported type found
+    }
+    if (!(item.name in shape) || shape[item.name] !== jsType) {
+      return false
+    }
+  }
+  return true
+}
+
+export type UqiMappedType =
+  | 'String'
+  | 'Number'
+  | 'Boolean'
+  | 'BigInt'
+  | 'Date'
+  | 'JSON'
+
+export default UqiDataProvider

--- a/packages/open-truss/src/components/index.ts
+++ b/packages/open-truss/src/components/index.ts
@@ -1,9 +1,12 @@
 import * as _OTExampleComponent from './OTExampleComponent'
 import * as _OTAvailableWorkflowsFromEndpoint from './OTAvailableWorkflowsFromEndpoint'
+import * as _OTUqiDataProvider from './OTUqiDataProvider'
 export const OTExampleComponent = _OTExampleComponent
+export const OTUqiDataProvider = _OTUqiDataProvider
 export const OTAvailableWorkflowsFromEndpoint =
   _OTAvailableWorkflowsFromEndpoint
 export const OT_COMPONENTS = {
   OTAvailableWorkflowsFromEndpoint,
   OTExampleComponent,
+  OTUqiDataProvider,
 }

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -100,8 +100,11 @@ export function Frame(props: FrameContext): React.JSX.Element {
         return <Component {...processedProps} />
       }
     }
+    // TODO update process props to pass in signals even if not
+    // declared by component
+    processedProps['results'] = signals['results']
 
-    return <Component {...props}>{subframes}</Component>
+    return <Component {...processedProps}>{subframes}</Component>
   } catch (e: any) {
     return <ShowError error={e} />
   }

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -100,9 +100,6 @@ export function Frame(props: FrameContext): React.JSX.Element {
         return <Component {...processedProps} />
       }
     }
-    // TODO update process props to pass in signals even if not
-    // declared by component
-    processedProps['results'] = signals['results']
 
     return <Component {...processedProps}>{subframes}</Component>
   } catch (e: any) {
@@ -239,6 +236,11 @@ function processProps({
       const prop = viewProps[propName]
       if (isComponent(prop)) {
         newProps[propName] = getDefaultComponent(prop, configPath, COMPONENTS)
+      }
+      if (isSymbol(prop)) {
+        const signalName = parseSignalName(prop) ?? ''
+        const signal = signals[signalName]
+        if (signal) newProps[propName] = signal
       }
     }
   }

--- a/packages/open-truss/src/signals/index.ts
+++ b/packages/open-truss/src/signals/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { signal, type Signal } from '@preact/signals-react'
+export { Signal }
 export { effect, computed } from '@preact/signals-react'
 export type SignalsZodType = z.ZodDefault<z.ZodType<Signal<any>>>
 export type Signals = Record<string, Signal<any>>
@@ -45,3 +46,17 @@ export const NavigateFrameSignal = SignalType<NavigateFrame>(
   () => {},
 )
 export type NavigateFrameSignalType = z.infer<typeof NavigateFrameSignal>
+
+// Scalar types
+export const NumbersSignal = SignalType<number[]>('number[]', [])
+export const NumberSignal = SignalType<number>('number', 0)
+export const StringsSignal = SignalType<string[]>('string[]', [])
+export const StringSignal = SignalType<string>('string', '')
+export const BooleansSignal = SignalType<boolean[]>('boolean[]', [])
+export const BooleanSignal = SignalType<boolean>('boolean', false)
+
+// Collection types
+export const RecordsSignal = SignalType<Array<Record<string, any>>>(
+  'Records',
+  [],
+)


### PR DESCRIPTION
Paired with @jonmagic 

### Why

We need the ability to support flexibly querying data in OT

### How

This PR takes the approach of mostly re-using the signals architecture we built and building a Data Provider component, instead of developing a dedicated `data` annotation.

![‎localhost:3000otplayground4-trino-demo 2024-02-29 at 7 55 30 PM](https://github.com/open-truss/open-truss/assets/4481584/7f855779-7563-4a92-bf5a-b919c1a4a588)

### Notes

- We moved the scalar signals to the OT package so that they can be used by the `OTUqiDataProvider` component
- We made a first pass at making the `OtUquiDataProvider` component
  - This component accepts a `query` and `source` argument to use for issuing a uqi query. The `output` argument specifies the signal name and the shape of the data that will be passed into the signal. If the shape is an array with an object, it will validate that the uqi rows have the same field and type names and return all the uqi results. If the shape is an object, it will do this check on just the first row and return just the first row.
  - This is an MVP data provider component that we want to ship so Jon can start using. There will be many follow up PRs necessary to improve this. See below.

### Follow ups

- Update component to only set the fields that the output has declared. Currently it just validates the fields exist in the results, but sets all the fields into the signal
- Support pagination
- Update component to set `isLoading` signal that can be used by display components to render loading indicators. Add `isLoading` to the base open truss component type so it's available in all components
- Update signals so that you can declare them at every frame level and signal name resolution moves up recursively up the frame parent tree. Similar to variable scoping in programming and how you can access variables in outer closures.
- Update component to support output annotations that are scalars instead of just arrays of objects or objects
