### PR TITLE
Make compatible with react 17

### DIFF
--- a/demo-app/src/pages/ot/config-builder/ComponentList.tsx
+++ b/demo-app/src/pages/ot/config-builder/ComponentList.tsx
@@ -26,7 +26,7 @@ function PropInputs({
   component: OpenTrussComponentExports
   onChange: (propName: string) => (value: YamlType) => void
   props: ViewProps
-}): React.JSX.Element | null {
+}): JSX.Element | null {
   const niceProps = describeZod(component.Props.shape)
 
   return (
@@ -52,7 +52,7 @@ function ComponentListItem({
 }: {
   componentName: string
   ALL_COMPONENTS: COMPONENTS
-}): React.JSX.Element {
+}): JSX.Element {
   const component = ALL_COMPONENTS[componentName]
   const { addFrame } = useConfigBuilderContext()
   const [props, setProps] = useState<ViewProps>(undefined)
@@ -97,7 +97,7 @@ interface ComponentListInterface {
 
 export default function ComponentList({
   components,
-}: ComponentListInterface): React.JSX.Element {
+}: ComponentListInterface): JSX.Element {
   const ALL_COMPONENTS = React.useMemo(() => {
     return {
       ...components,

--- a/demo-app/src/pages/ot/config-builder/ConfigYaml.tsx
+++ b/demo-app/src/pages/ot/config-builder/ConfigYaml.tsx
@@ -2,7 +2,7 @@ import { useConfigBuilderContext } from '@open-truss/open-truss'
 
 const FRAMES_PATH_PARTS = ['workflow:', 'frames:', '- frame:']
 
-export default function ConfigYaml(): React.JSX.Element {
+export default function ConfigYaml(): JSX.Element {
   const { config, framesPath, setFramesPath } = useConfigBuilderContext()
   const framesPathParts: Array<number | string> = []
 

--- a/demo-app/src/pages/ot/config-builder/PropInput.tsx
+++ b/demo-app/src/pages/ot/config-builder/PropInput.tsx
@@ -14,7 +14,7 @@ export default function PropInput({
   onChange: (value: YamlType) => void
   type: ZodDescriptionObject
   value?: string
-}): React.JSX.Element | null {
+}): JSX.Element | null {
   const defaultValue = type.defaultValue as string
   value = value ?? defaultValue
 

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.3.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.3.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -44,6 +44,7 @@
       "types": "./dist/mjs/pages.d.ts"
     }
   },
+  "typings": "./dist/mjs/index.d.ts",
   "dependencies": {
     "@preact/signals-react": "^2.0.0",
     "crypto-js": "^4.2.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/configuration/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/RenderConfig.tsx
@@ -28,7 +28,7 @@ export function RenderConfig({
   components: COMPONENTS
   config: string
   validateConfig?: boolean
-}): React.JSX.Element {
+}): JSX.Element {
   const components = Object.assign({}, appComponents, OT_COMPONENTS)
   const parsedConfig = parseYaml(config)
   const workflow = (parsedConfig as unknown as WorkflowSpec).workflow

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -55,7 +55,7 @@ function ShowError({ error }: { error: FrameError }): JSX.Element {
   )
 }
 
-export function Frame(props: FrameContext): React.JSX.Element {
+export function Frame(props: FrameContext): JSX.Element {
   const {
     frame: { view, data, frames },
     globalContext: { COMPONENTS, signals },
@@ -72,9 +72,9 @@ export function Frame(props: FrameContext): React.JSX.Element {
     let subframes
     const renderType = props?.frame?.renderFrames?.type
     if (renderType === 'inSequence') {
-      subframes = <FramesInSequence {...props} reRender={reRender} />
+      subframes = FramesInSequence({ ...props, reRender })
     } else {
-      subframes = <AllFrames {...props} />
+      subframes = AllFrames({ ...props })
     }
 
     if (component === '__FRAGMENT__') {
@@ -111,7 +111,9 @@ interface FramesInSequenceProps extends FrameContext {
   reRender: () => void
 }
 
-const FramesInSequence: React.FC<FramesInSequenceProps> = (props) => {
+const FramesInSequence = (
+  props: FramesInSequenceProps,
+): JSX.Element[] | undefined => {
   const {
     frame: {
       frames,
@@ -183,7 +185,7 @@ function setFrameCursor(
   setWorkflowSessionValue(workflowId, fl, frameNumber)
 }
 
-const AllFrames: React.FC<FrameContext> = (props) => {
+const AllFrames = (props: FrameContext): JSX.Element[] | undefined => {
   const {
     frame: { frames },
     globalContext: { FrameWrapper },

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -40,7 +40,7 @@ export function RenderConfig({
   COMPONENTS: COMPONENTS
   config: WorkflowV1
   validateConfig?: boolean
-}): React.JSX.Element {
+}): JSX.Element {
   COMBINED_COMPONENTS = Object.assign({}, COMPONENTS, { OTDefaultFrameWrapper })
   // Runs validations in config-schemas
   let config = _config

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -127,9 +127,7 @@ type BaseOpenTrussComponentV1Props = z.infer<
 
 export type BaseOpenTrussComponentV1<
   AdditionalProps = Record<string, unknown>,
-> = (
-  props: BaseOpenTrussComponentV1Props & AdditionalProps,
-) => React.JSX.Element
+> = (props: BaseOpenTrussComponentV1Props & AdditionalProps) => JSX.Element
 
 export const withChildren = { children: z.any().optional() }
 const ComponentWithChildrenShape =

--- a/packages/open-truss/src/hooks/config-builder.tsx
+++ b/packages/open-truss/src/hooks/config-builder.tsx
@@ -34,9 +34,9 @@ export const useConfigBuilderContext = (): ConfigBuilder => {
   return useContext(ConfigBuilderContext)
 }
 
-export const ConfigBuilderContextProvider: React.FC<
-  React.PropsWithChildren
-> = ({ children }) => {
+export const ConfigBuilderContextProvider: React.FC<{
+  children: JSX.Element
+}> = ({ children }) => {
   const [config, setConfig] = useState<string>(CONFIG_BASE)
   const [framesPath, _setFramesPath] = useState<string>(INITIAL_FRAMES_PATH)
 


### PR DESCRIPTION
### Why

Some consumers of OT use React 17. We should try and make this compatible with that.

### How

React 18 has types that don't exist in React 17. This PR removes usage of those types where they are not necessary, while making this still work for React 18. e.g. changing `React.JSX.Element` -> `JSX.Element`. 

Additionally, this PR adds a missing `typings` declaration in the package.json config that supports targets that don't know how to use the `exports` annotation to find typedefs. e.g. `moduleResolution: node`.

### Consideration

While this PR resolves the conflicts for React 17, it does bring up a larger issue of how do we want to prevent breaking changes like this in the future or also do we even want to support React 17 long-term. Some ideas:
- As a general rule of thumb, we can try not using `React` types directly in the core OT library as those change between versions.
- Perhaps we should in the long-term not support React 17. The app we use at our day job hopefully will migrated over to 18 soon and this may become less of an issue.
- If we want to support both version, perhaps we can setup multiple test environments for each react version to catch these types of issues.

### Debugging tips

Confusingly, when importing OT into a React 17 app instead showing errors in the OT package it instead broke every object using React types in the app's source code. There were around 2700 errors. This was a red herring as the error originated from the OT package. I still am not sure why this error manifested the way it did and why the compiler would show the app's source code as having errors. Perhaps when importing OT it was importing React 18, redeclaring the types, and breaking the apps source? I double checked using `npm ls @types/react` that the versions were 17 but perhaps this is not comprehensive?

When working on our app we need to make sure to link the package's react and @types/react version to our app's packages so that there are not multiple versions being used. This should probably be scripted away and handled seamlessly. 

/cc @jonmagic @kmcq 