### PR TITLE
Add styling to `SimpleSignalExample`

### DIFF
--- a/demo-app/src/open-truss/components/SimpleSignalExample.tsx
+++ b/demo-app/src/open-truss/components/SimpleSignalExample.tsx
@@ -29,21 +29,19 @@ export default function SimpleSignalExample({
   }
 
   return (
-    <div
-      className="m-6 flex flex-col"
-    >
+    <div className="m-6 flex flex-col">
       <h2>Currently selected AccountIDs: {accountIDsString}</h2>
-      <div
-        className="flex flex-row mt-2 w-1/2 justify-start items-center"
-      >
+      <div className="flex flex-row mt-2 w-1/2 justify-start items-center">
         <input
           className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
           type="number"
           value={inputValue}
-          onChange={handleInputChange} />
+          onChange={handleInputChange}
+        />
         <button
           className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm mt-2 px-5 ml-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
-          onClick={addAccountId}>
+          onClick={addAccountId}
+        >
           Add account ID
         </button>
       </div>

--- a/demo-app/src/open-truss/components/SimpleSignalExample.tsx
+++ b/demo-app/src/open-truss/components/SimpleSignalExample.tsx
@@ -3,8 +3,8 @@ import {
   computed,
   type z,
 } from '@open-truss/open-truss'
-import { AccountIDsSignal } from '../signals'
 import { useState } from 'react'
+import { AccountIDsSignal } from '../signals'
 
 export const Props = BaseOpenTrussComponentV1PropsShape.extend({
   accountIds: AccountIDsSignal,
@@ -29,10 +29,24 @@ export default function SimpleSignalExample({
   }
 
   return (
-    <div>
+    <div
+      className="m-6 flex flex-col"
+    >
       <h2>Currently selected AccountIDs: {accountIDsString}</h2>
-      <input type="number" value={inputValue} onChange={handleInputChange} />
-      <button onClick={addAccountId}>Add account ID</button>
+      <div
+        className="flex flex-row mt-2 w-1/2 justify-start items-center"
+      >
+        <input
+          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          type="number"
+          value={inputValue}
+          onChange={handleInputChange} />
+        <button
+          className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm mt-2 px-5 ml-5 py-2.5 me-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+          onClick={addAccountId}>
+          Add account ID
+        </button>
+      </div>
     </div>
   )
 }

--- a/demo-app/src/pages/ot/playground/[slug]/index.tsx
+++ b/demo-app/src/pages/ot/playground/[slug]/index.tsx
@@ -1,7 +1,7 @@
+import * as _components from '@/open-truss/components'
+import { RenderFromEndpoint, type COMPONENTS } from '@open-truss/open-truss'
 import { useRouter } from 'next/router'
 import path from 'path'
-import { RenderFromEndpoint, type COMPONENTS } from '@open-truss/open-truss'
-import * as _components from '@/open-truss/components'
 const components = _components as unknown as COMPONENTS
 
 export default function Page(): JSX.Element {
@@ -14,7 +14,9 @@ export default function Page(): JSX.Element {
 
   return (
     <>
-      <h1>{sanitizedSlug}</h1>
+      <h1
+        className='text-4xl font-bold text-center'
+      >{sanitizedSlug}</h1>
       <RenderFromEndpoint
         configName={sanitizedSlug}
         components={components}

--- a/demo-app/src/pages/ot/playground/[slug]/index.tsx
+++ b/demo-app/src/pages/ot/playground/[slug]/index.tsx
@@ -14,9 +14,7 @@ export default function Page(): JSX.Element {
 
   return (
     <>
-      <h1
-        className='text-4xl font-bold text-center'
-      >{sanitizedSlug}</h1>
+      <h1 className="text-4xl font-bold text-center">{sanitizedSlug}</h1>
       <RenderFromEndpoint
         configName={sanitizedSlug}
         components={components}

--- a/demo-app/tsconfig.json
+++ b/demo-app/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,18 +20,9 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Resolves https://github.com/open-truss/open-truss/issues/143

Updated the state management demo page by styling the `SimpleSignalExample` and the `H1` in `playground/index`

Changes from this PR:
<img width="1716" alt="image" src="https://github.com/open-truss/open-truss/assets/55855284/fc6deb40-10fb-430e-bc22-aab4654c1254">

Found https://flowbite.com/docs/components/buttons/ and https://tailwindcss.com/docs/flex-direction to be helpful for styling