### PR TITLE
Update parseYaml function to take optional generic type

### DIFF
--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/hooks/config-builder.tsx
+++ b/packages/open-truss/src/hooks/config-builder.tsx
@@ -45,7 +45,7 @@ export const ConfigBuilderContextProvider: React.FC<{
   }, [])
 
   const addFrame = (frame: FrameType): void => {
-    const parsedConfig = parseYaml(config) as unknown as WorkflowSpec
+    const parsedConfig = parseYaml<WorkflowSpec>(config)
     const frames = (get(parsedConfig, framesPath, []) as FrameType[]).concat(
       frame,
     )
@@ -60,7 +60,7 @@ export const ConfigBuilderContextProvider: React.FC<{
     if (!framePath) {
       return
     }
-    const parsedConfig = parseYaml(config) as unknown as WorkflowSpec
+    const parsedConfig = parseYaml<WorkflowSpec>(config)
     const framePathParts = framePath.split('.')
     const frameToDeleteIndex = Number(framePathParts.pop())
     const thisFramesFramesPath = framePathParts.join('.')

--- a/packages/open-truss/src/utils/yaml.test.ts
+++ b/packages/open-truss/src/utils/yaml.test.ts
@@ -26,4 +26,8 @@ test('parseYaml', () => {
     { foo: [4, 2, 1] },
   ])
   expect(parseYaml('- foo:\n    - baz: 4')).toEqual([{ foo: [{ baz: 4 }] }])
+  expect(parseYaml<{ foo: string; bar: number }>('foo: bar')).toEqual({
+    foo: 'bar',
+    bar: 0,
+  })
 })

--- a/packages/open-truss/src/utils/yaml.test.ts
+++ b/packages/open-truss/src/utils/yaml.test.ts
@@ -26,8 +26,8 @@ test('parseYaml', () => {
     { foo: [4, 2, 1] },
   ])
   expect(parseYaml('- foo:\n    - baz: 4')).toEqual([{ foo: [{ baz: 4 }] }])
-  expect(parseYaml<{ foo: string; bar: number }>('foo: bar')).toEqual({
+  expect(parseYaml<{ foo: string; baz: number }>('foo: bar\nbaz: 0')).toEqual({
     foo: 'bar',
-    bar: 0,
+    baz: 0,
   })
 })

--- a/packages/open-truss/src/utils/yaml.ts
+++ b/packages/open-truss/src/utils/yaml.ts
@@ -18,7 +18,7 @@ export const YamlShape: z.ZodType<YamlType> = yamlScalars
   .or(z.lazy(() => YamlObjectShape))
 export const YamlObjectShape = z.record(z.string(), YamlShape)
 
-export function parseYaml(yamlString: string): YamlObject {
+export function parseYaml<T = YamlObject>(yamlString: string): T {
   return yaml.parse(yamlString)
 }
 


### PR DESCRIPTION
## Why?

Because we ran into a situation where we wanted this and it did not support it.

**PLEASE NOTE** this does not actually do runtime type checking on the parsed version of the yaml string being parsed. If we want that we should incorporate zod into this function.

Co-authored-by @spicycode, @tmetz, @hktouw, @andrew-dillon, @fionaochs