### PR TITLE
Uppercase keywords be default in query formatter

### DIFF
--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/utils/format.ts
+++ b/packages/open-truss/src/utils/format.ts
@@ -30,9 +30,9 @@ function formatParams(params: Record<string, Param>): Record<string, string> {
 export function formatQuery(template: string, config?: Config): string {
   return sqlFormat(template, {
     language: config?.language || 'sql',
-    tabWidth: 4,
     linesBetweenQueries: 2,
-    paramTypes: { named: [':'] },
     params: config?.params ? formatParams(config.params) : undefined,
+    paramTypes: { named: [':'] },
+    tabWidth: 4,
   })
 }

--- a/packages/open-truss/src/utils/format.ts
+++ b/packages/open-truss/src/utils/format.ts
@@ -29,6 +29,7 @@ function formatParams(params: Record<string, Param>): Record<string, string> {
 
 export function formatQuery(template: string, config?: Config): string {
   return sqlFormat(template, {
+    keywordCase: 'upper',
     language: config?.language || 'sql',
     linesBetweenQueries: 2,
     params: config?.params ? formatParams(config.params) : undefined,


### PR DESCRIPTION
## Why?

Because it was bugging me that this wasn't the default 😬 