### PR TITLE
Expose more of @preact/react-signals and make switching apps easier

### DIFF
--- a/demo-app/script/bootstrap
+++ b/demo-app/script/bootstrap
@@ -6,6 +6,7 @@ script_dir=$(dirname "$(readlink -f "$0")")
 demo_app_dir=$(dirname "$script_dir")
 root_dir=$(dirname "$demo_app_dir")
 open_truss_package_dir="$root_dir/packages/open-truss"
+react_path=$(readlink -f $open_truss_package_dir/node_modules/react)
 
 set -e
 
@@ -33,7 +34,7 @@ checksum() {
 # Check if the checksum matches the current configuration and exit early if it does.
 checksum_path=".checksum"
 if [ "$1" != "--force" ] && [ "$1" != "-f" ]; then
-  if [ -f $checksum_path ] && [ "$(cat $checksum_path)" = "$(checksum)" ]; then
+  if [ -f $checksum_path ] && [ "$(cat $checksum_path)" = "$(checksum)" ] && [[ $react_path == *"demo-app/node_modules/react" ]]; then
     echo "All dependencies are up to date."
     exit 0
   fi

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.5.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.5.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/index.ts
+++ b/packages/open-truss/src/index.ts
@@ -10,4 +10,13 @@ export * from './utils/format'
 export * from './utils/yaml'
 export * from './utils/misc'
 export { z } from 'zod'
-export { useComputed } from '@preact/signals-react'
+export {
+  batch,
+  computed,
+  effect,
+  signal,
+  untracked,
+  useComputed,
+  useSignal,
+  useSignalEffect,
+} from '@preact/signals-react'


### PR DESCRIPTION
## Why?

I would like to have access to all of the public API from the `@preact/signals-react` library. I also need to switch between development on my work app and the demo-app easier. We already had things working on the work app but when switching back to the demo-app it wasn't fixing the npm link for react.

## How?

See commits.