### PR TITLE
Add debug flag

### DIFF
--- a/demo-app/src/open-truss/configs/4-trino-demo.yaml
+++ b/demo-app/src/open-truss/configs/4-trino-demo.yaml
@@ -1,5 +1,6 @@
 workflow:
   version: 1
+  debug: true
   signals:
     resultsArray: # OTUqiDataProvider returns collection with rows using the shape of the object
       - name: string

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/components/OTUqiDataProvider.tsx
+++ b/packages/open-truss/src/components/OTUqiDataProvider.tsx
@@ -23,9 +23,10 @@ export const Props = BaseOpenTrussComponentV1PropsShape.extend({
 const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
   props,
 ) => {
-  const { query, children, output, source } = props
+  const { query, children, output, source, debug } = props
 
   useSignalEffect(() => {
+    if (debug) console.log({ query: query.value, source: source.value })
     let queryResults: SynchronousQueryResult
     if (query.value === '') return
     const fetchData = async function (): Promise<undefined> {
@@ -35,6 +36,7 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
         body: JSON.stringify({ query, source }),
       })
       const deserialized = await result.json()
+      if (debug) console.log({ api_response: result })
       queryResults = deserialized
     }
 
@@ -54,6 +56,12 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
             : parsedResults[0]?.[signal.yamlName]
 
           const validatedResult = shape.parse(result)
+          if (debug)
+            console.log({
+              message: 'formated query results',
+              signal_name: signal.yamlName,
+              result: validatedResult,
+            })
           signal.value = validatedResult
         }
       })

--- a/packages/open-truss/src/components/OTUqiDataProvider.tsx
+++ b/packages/open-truss/src/components/OTUqiDataProvider.tsx
@@ -26,10 +26,10 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
   props,
 ) => {
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  const { query, force_query, children, output, source, debug } = props
+  const { query, force_query, children, output, source, _DEBUG_ } = props
 
   useSignalEffect(() => {
-    if (debug) console.log({ query: query.value, source: source.value })
+    if (_DEBUG_) console.log({ m: 'Query values', query, source })
     let queryResults: SynchronousQueryResult
     if (query.value === '') return
     const fetchData = async function (): Promise<undefined> {
@@ -45,7 +45,7 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
         body: JSON.stringify({ query, source }),
       })
       const deserialized = await result.json()
-      if (debug) console.log({ api_response: result })
+      if (_DEBUG_) console.log({ m: 'UQI API response', response: result })
       queryResults = deserialized
     }
 
@@ -65,11 +65,11 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
             : parsedResults[0]?.[signal.yamlName]
 
           const validatedResult = shape.parse(result)
-          if (debug)
+          if (_DEBUG_)
             console.log({
-              message: 'formated query results',
-              signal_name: signal.yamlName,
-              result: validatedResult,
+              m: 'Parsed UQI results',
+              signal: signal.yamlName,
+              validatedResult,
             })
           signal.value = validatedResult
         }

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -59,7 +59,7 @@ function ShowError({ error }: { error: FrameError }): JSX.Element {
 export function Frame(props: FrameContext): JSX.Element {
   const {
     frame: { view, data, frames },
-    globalContext: { COMPONENTS, signals },
+    globalContext: { COMPONENTS, signals, debug },
     configPath,
   } = props
   const { component, props: viewProps } = view
@@ -91,6 +91,7 @@ export function Frame(props: FrameContext): JSX.Element {
       signals,
       componentName: component,
     })
+    processedProps.debug = debug
 
     if (frames === undefined) {
       if (data) {

--- a/packages/open-truss/src/configuration/engine-v1/Frame.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/Frame.tsx
@@ -91,7 +91,7 @@ export function Frame(props: FrameContext): JSX.Element {
       signals,
       componentName: component,
     })
-    processedProps.debug = debug
+    processedProps._DEBUG_ = debug
 
     if (frames === undefined) {
       if (data) {

--- a/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/RenderConfig.tsx
@@ -23,6 +23,7 @@ export interface GlobalContext {
   signals: Signals
   FrameWrapper: FrameWrapper
   workflowId: string
+  debug: boolean
 }
 
 let COMBINED_COMPONENTS: COMPONENTS
@@ -59,6 +60,7 @@ export function RenderConfig({
     configPath,
     COMBINED_COMPONENTS,
   ) as FrameWrapper
+  const debug = config.debug ?? false
 
   const signals = createSignals(config.signals, validateConfig)
 
@@ -79,6 +81,7 @@ export function RenderConfig({
     COMPONENTS: COMBINED_COMPONENTS,
     FrameWrapper,
     workflowId,
+    debug,
   }
   useSetWorkflowSession(workflowId)
   // Workflows are just frames! Use unknown to convince TS of this fact.

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -120,7 +120,7 @@ export type WorkflowV1 = z.infer<typeof WorkflowV1Shape>
 export const BaseOpenTrussComponentV1PropsShape = z.object({
   data: DataV1Shape,
   config: WorkflowV1Shape.optional(),
-  debug: z.boolean().optional(),
+  _DEBUG_: z.boolean().optional(),
 })
 
 type BaseOpenTrussComponentV1Props = z.infer<

--- a/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
+++ b/packages/open-truss/src/configuration/engine-v1/config-schemas.tsx
@@ -107,6 +107,7 @@ export type SignalsV1 = z.infer<typeof SignalsV1Shape>
 export const WorkflowV1Shape = z.object({
   id: z.string().optional(),
   version: z.number().positive(),
+  debug: z.boolean().optional(),
   signals: SignalsV1Shape,
   frameWrapper: z.string().optional(),
   frames: FramesV1Shape,
@@ -119,6 +120,7 @@ export type WorkflowV1 = z.infer<typeof WorkflowV1Shape>
 export const BaseOpenTrussComponentV1PropsShape = z.object({
   data: DataV1Shape,
   config: WorkflowV1Shape.optional(),
+  debug: z.boolean().optional(),
 })
 
 type BaseOpenTrussComponentV1Props = z.infer<


### PR DESCRIPTION
To make debugging easier in OT components, this PR extends the base OT component type with a `debug` prop. OT components can then opt into using that prop to output useful debugging results. Debugging is then enabled by setting `debug: true` at the top of the config file. Later, this may wanted to be set elsewhere, but this felt like the most sense for the time being.

You can see in this demo, debugging is added to the `OTUquiDataprovider` component.

https://github.com/open-truss/open-truss/assets/4481584/f52cf631-8b07-473d-ab6a-ca9c68a77eb0

/cc @open-truss/engineers 