### PR TITLE
Add JSON type to mysql type mappings

### DIFF
--- a/demo-app/src/lib/mysql-uqi-client.ts
+++ b/demo-app/src/lib/mysql-uqi-client.ts
@@ -45,6 +45,7 @@ export default async function (config: MysqlConfig): Promise<UqiClient> {
     '14': 'String', // 'NEWDATE'
     '15': 'String', // 'VARCHAR'
     '16': 'Boolean', // 'BIT'
+    '245': 'JSON', // 'JSON'
     '246': 'Number', // 'NEWDECIMAL'
     '247': 'String', // 'ENUM'
     '248': 'JSON', // 'SET'


### PR DESCRIPTION
## Why?

I'm using the mysql-uqi-client in the demo-app to power the stored queries primitive and when I tried to use the mysql JSON type got an error because that type wasn't included in the type mappings.

## How?

Added the missing type to the mysql-uqi-client type mappings.