### PR TITLE
Set engine and engine version

### DIFF
--- a/demo-app/src/lib/kusto-uqi-client.ts
+++ b/demo-app/src/lib/kusto-uqi-client.ts
@@ -52,7 +52,7 @@ interface KustoConfig {
   endpoint: string
 }
 
-export default async function (config: KustoConfig): Promise<UqiClient> {
+async function createKustoUqiClient(config: KustoConfig): Promise<UqiClient> {
   const typeMappings: Record<string, UqiMappedType> = {
     bool: 'Boolean',
     datetime: 'Date',
@@ -112,3 +112,8 @@ export default async function (config: KustoConfig): Promise<UqiClient> {
     query,
   })
 }
+
+createKustoUqiClient.engine = 'kusto'
+createKustoUqiClient.engine_version = 'v3'
+
+export { createKustoUqiClient }

--- a/demo-app/src/lib/mysql-uqi-client.ts
+++ b/demo-app/src/lib/mysql-uqi-client.ts
@@ -24,7 +24,7 @@ function makeUqiColumnCompatible(fields: FieldPacket[]): UqiColumn[] {
   })
 }
 
-export default async function (config: MysqlConfig): Promise<UqiClient> {
+async function createMysqlUqiClient(config: MysqlConfig): Promise<UqiClient> {
   const parsedUrl = new URL(config.uri)
 
   const typeMappings: Record<string, UqiMappedType> = {
@@ -118,3 +118,8 @@ export default async function (config: MysqlConfig): Promise<UqiClient> {
     query,
   })
 }
+
+createMysqlUqiClient.engine = 'mysql'
+createMysqlUqiClient.engine_version = '8.0.37'
+
+export { createMysqlUqiClient }

--- a/demo-app/src/lib/trino-uqi-client.ts
+++ b/demo-app/src/lib/trino-uqi-client.ts
@@ -19,7 +19,7 @@ export interface TrinoConfig {
   source?: string
 }
 
-export default async function (config: TrinoConfig): Promise<UqiClient> {
+async function createTrinoUqiClient(config: TrinoConfig): Promise<UqiClient> {
   const typeMappings: Record<string, UqiMappedType> = {
     boolean: 'Boolean',
     integer: 'Number',
@@ -71,3 +71,8 @@ export default async function (config: TrinoConfig): Promise<UqiClient> {
     query,
   })
 }
+
+createTrinoUqiClient.engine = 'trino'
+createTrinoUqiClient.engine_version = '447'
+
+export { createTrinoUqiClient }

--- a/demo-app/src/lib/uqi-sources.ts
+++ b/demo-app/src/lib/uqi-sources.ts
@@ -1,6 +1,6 @@
-import createKustoUqiClient from '@/lib/kusto-uqi-client'
-import createMysqlUqiClient from '@/lib/mysql-uqi-client'
-import createTrinoUqiClient from '@/lib/trino-uqi-client'
+import { createKustoUqiClient } from '@/lib/kusto-uqi-client'
+import { createMysqlUqiClient } from '@/lib/mysql-uqi-client'
+import { createTrinoUqiClient } from '@/lib/trino-uqi-client'
 
 const sources = {
   // setup local trino with this:


### PR DESCRIPTION
## Why?

When executing a query it would be nice to be able to reference what query engine and engine version that the uqi client was meant to work with.

Right now I want this for https://github.com/open-truss/open-truss/issues/169 so I can add a referenced in the stored query to the engine that was being used.

## How?

Refactor and put the `engine` and `engine_version` directly on the create function for each client.