### PR TITLE
Improve support for Array signals

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -55,7 +55,7 @@
     },
     "../packages/open-truss": {
       "name": "@open-truss/open-truss",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/demo-app/src/lib/trino-uqi-client.ts
+++ b/demo-app/src/lib/trino-uqi-client.ts
@@ -27,6 +27,7 @@ async function createTrinoUqiClient(config: TrinoConfig): Promise<UqiClient> {
     bigint: 'BigInt',
     varchar: 'String',
     row: 'JSON',
+    array: 'JSON',
   }
 
   async function query(

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -6,6 +6,9 @@ workflow:
       value: number[]
     r2:
       value: string[]
+    r3:
+      value:
+        - number[]
   frames:
     - frame:
       view:
@@ -35,3 +38,17 @@ workflow:
             component: DataDemo
             props:
               results: :r2
+    - frame:
+      view:
+        component: OTUqiDataProvider
+        props:
+          source: trino-demo
+          query: >
+            SELECT ARRAY[ ARRAY[1], NULL, ARRAY[3] ] AS value
+          output: [:r3]
+      frames:
+        - frame:
+          view:
+            component: DataDemo
+            props:
+              results: :r3

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -25,9 +25,9 @@ workflow:
       view:
         component: OTUqiDataProvider
         props:
-          source: trino-demo
+          source: mysql-demo
           query: >
-            SELECT ARRAY[ 'one', NULL, 'three' ] AS value
+            SELECT JSON_ARRAY( 'one', NULL, 'three' ) AS value
           output: [:r2]
       frames:
         - frame:

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -10,9 +10,9 @@ workflow:
       view:
         component: OTUqiDataProvider
         props:
-          source: mysql-demo
+          source: trino-demo
           query: >
-            SELECT JSON_ARRAY(1, NULL, 3) AS value
+            SELECT ARRAY[ 1, NULL, 3 ] AS value
           output: [:r1]
       frames:
         - frame:
@@ -24,9 +24,9 @@ workflow:
       view:
         component: OTUqiDataProvider
         props:
-          source: mysql-demo
+          source: trino-demo
           query: >
-            SELECT JSON_ARRAY('one', NULL, 'three') AS value
+            SELECT ARRAY[ 'one', NULL, 'three' ] AS value
           output: [:r2]
       frames:
         - frame:

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -1,0 +1,36 @@
+workflow:
+  version: 1
+  signals:
+    r1:
+      value: number[]
+    r2:
+      value: string[]
+  frames:
+    - frame:
+      view:
+        component: OTUqiDataProvider
+        props:
+          source: mysql-demo
+          query: >
+            SELECT JSON_ARRAY(1, NULL, 3) AS value
+          output: [:r1]
+      frames:
+        - frame:
+          view:
+            component: DataDemo
+            props:
+              results: :r1
+    - frame:
+      view:
+        component: OTUqiDataProvider
+        props:
+          source: mysql-demo
+          query: >
+            SELECT JSON_ARRAY('one', NULL, 'three') AS value
+          output: [:r2]
+      frames:
+        - frame:
+          view:
+            component: DataDemo
+            props:
+              results: :r2

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -6,9 +6,12 @@ workflow:
       value: number[]
     r2:
       value: string[]
-    r3:
+    multiDimensionalArray:
       value:
         - number[]
+    multiDimensionalArray2:
+      value:
+        - - number
   frames:
     - frame:
       view:
@@ -45,10 +48,15 @@ workflow:
           source: trino-demo
           query: >
             SELECT ARRAY[ ARRAY[1], NULL, ARRAY[3] ] AS value
-          output: [:r3]
+          output: [:multiDimensionalArray, :multiDimensionalArray2]
       frames:
         - frame:
           view:
             component: DataDemo
             props:
-              results: :r3
+              results: :multiDimensionalArray
+        - frame:
+          view:
+            component: DataDemo
+            props:
+              results: :multiDimensionalArray2

--- a/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
+++ b/demo-app/src/open-truss/configs/15-arrays-signals-from-query.yaml
@@ -1,5 +1,6 @@
 workflow:
   version: 1
+  debug: true
   signals:
     r1:
       value: number[]

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/signals/index.tsx
+++ b/packages/open-truss/src/signals/index.tsx
@@ -171,17 +171,17 @@ export const NavigateFrameSignal = SignalType<NavigateFrame>(
 export type NavigateFrameSignalType = z.infer<typeof NavigateFrameSignal>
 
 // Scalar types
-export const NumbersSignal = SignalType<(number | null)[]>(
+export const NumbersSignal = SignalType<Array<number | null>>(
   'number[]',
   z.array(z.number().nullable()).default([]),
 )
 export const NumberSignal = SignalType<number>('number', z.number().default(0))
-export const StringsSignal = SignalType<(string | null)[]>(
+export const StringsSignal = SignalType<Array<string | null>>(
   'string[]',
   z.array(z.string().nullable()).default([]),
 )
 export const StringSignal = SignalType<string>('string', z.string().default(''))
-export const BooleansSignal = SignalType<(boolean | null)[]>(
+export const BooleansSignal = SignalType<Array<boolean | null>>(
   'boolean[]',
   z.array(z.boolean().nullable()).default([]),
 )

--- a/packages/open-truss/src/signals/index.tsx
+++ b/packages/open-truss/src/signals/index.tsx
@@ -106,7 +106,7 @@ export function SignalType<T>(
 // - TODO it accepts predefined higher order types as valid types
 export function createSignal(
   configName: string,
-  signal: object | object[],
+  signal: object,
 ): SignalsZodType {
   const name = `${configName}-${signalNameFromObject(signal)}`
   if (name in SIGNALS) return SIGNALS[name].signal
@@ -120,44 +120,40 @@ function signalNameFromObject(signal: object | object[]): string {
   return CryptoJS.SHA256(s).toString()
 }
 
-function createZodShape(signal: object | object[]): {
-  zodShape: ZodTypeAny
-  defaultValue: object | object[]
-} {
-  if (Array.isArray(signal)) {
-    const signalObject = signal?.[0]
-    if (!isObject(signalObject))
-      throw new Error('Array signals must be an object as first and only value')
+type DefaultValue = object | object[] | string | boolean | number
 
-    const { zodShape, defaultValue } = createZodShape(signalObject)
+interface createZodShapeReturn {
+  zodShape: ZodTypeAny
+  defaultValue: DefaultValue
+}
+
+function createZodShape(signal: object): createZodShapeReturn {
+  if (Array.isArray(signal)) {
+    const { zodShape, defaultValue } = createZodShape(signal[0])
     return {
       zodShape: z.array(zodShape).nullable(),
       defaultValue: [defaultValue],
     }
-  } else {
+  } else if (isObject(signal)) {
     const zodSchema: Record<string, ZodTypeAny> = {}
-    const defaultValue: Record<
-      string,
-      string | boolean | number | object | object[]
-    > = {}
+    const defaultValue: Record<string, DefaultValue> = {}
 
     for (const [key, value] of Object.entries(signal)) {
-      if (isObject(value)) {
-        const { zodShape, defaultValue: defValue } = createZodShape(value)
-        zodSchema[key] = zodShape
-        defaultValue[key] = defValue
-      } else if (typeof value === 'string' && value in SIGNALS) {
-        zodSchema[key] = SIGNALS[value].valueShape
-        defaultValue[key] = SIGNALS[value].valueShape.parse(undefined)
-      } else if (typeof value === 'string' && value in typeToZodMap) {
-        zodSchema[key] = typeToZodMap[value].nullable()
-        defaultValue[key] = typeToDefaultValue[value]
-      } else {
-        throw new Error(`unknown signal value: ${value}`)
-      }
+      const { zodShape, defaultValue: defValue } = createZodShape(value)
+      zodSchema[key] = zodShape
+      defaultValue[key] = defValue
     }
-
     return { zodShape: z.object(zodSchema).nullable(), defaultValue }
+  } else if (typeof signal === 'string' && signal in SIGNALS) {
+    const zodShape = SIGNALS[signal].valueShape
+    const defaultValue = SIGNALS[signal].valueShape.parse(undefined)
+    return { zodShape, defaultValue }
+  } else if (typeof signal === 'string' && signal in typeToZodMap) {
+    const zodShape = typeToZodMap[signal].nullable()
+    const defaultValue = typeToDefaultValue[signal]
+    return { zodShape, defaultValue }
+  } else {
+    throw new Error(`unknown signal value: ${String(signal)}`)
   }
 }
 

--- a/packages/open-truss/src/signals/index.tsx
+++ b/packages/open-truss/src/signals/index.tsx
@@ -146,6 +146,9 @@ function createZodShape(signal: object | object[]): {
         const { zodShape, defaultValue: defValue } = createZodShape(value)
         zodSchema[key] = zodShape
         defaultValue[key] = defValue
+      } else if (typeof value === 'string' && value in SIGNALS) {
+        zodSchema[key] = SIGNALS[value].valueShape
+        defaultValue[key] = SIGNALS[value].valueShape.parse(undefined)
       } else if (typeof value === 'string' && value in typeToZodMap) {
         zodSchema[key] = typeToZodMap[value].nullable()
         defaultValue[key] = typeToDefaultValue[value]
@@ -168,19 +171,19 @@ export const NavigateFrameSignal = SignalType<NavigateFrame>(
 export type NavigateFrameSignalType = z.infer<typeof NavigateFrameSignal>
 
 // Scalar types
-export const NumbersSignal = SignalType<number[]>(
+export const NumbersSignal = SignalType<(number | null)[]>(
   'number[]',
-  z.array(z.number()).default([]),
+  z.array(z.number().nullable()).default([]),
 )
 export const NumberSignal = SignalType<number>('number', z.number().default(0))
-export const StringsSignal = SignalType<string[]>(
+export const StringsSignal = SignalType<(string | null)[]>(
   'string[]',
-  z.array(z.string()).default([]),
+  z.array(z.string().nullable()).default([]),
 )
 export const StringSignal = SignalType<string>('string', z.string().default(''))
-export const BooleansSignal = SignalType<boolean[]>(
+export const BooleansSignal = SignalType<(boolean | null)[]>(
   'boolean[]',
-  z.array(z.boolean()).default([]),
+  z.array(z.boolean().nullable()).default([]),
 )
 export const BooleanSignal = SignalType<boolean>(
   'boolean',

--- a/packages/open-truss/src/uqi/uqi.ts
+++ b/packages/open-truss/src/uqi/uqi.ts
@@ -20,8 +20,11 @@ export function castUqiValue(type: UqiMappedType, value: string): unknown {
       return BigInt(value)
     case 'Date':
       return Date.parse(value)
-    case 'JSON':
+    case 'JSON': {
+      // Case when JSON is already parsed
+      if (typeof value === 'object' || Array.isArray(value)) return value
       return JSON.parse(value)
+    }
     default:
       return value
   }


### PR DESCRIPTION
## Why?

We need signals to support array values because those are common return types and data structures in databases

```yaml
workflow:
  version: 1
  signals:
    r1:
      value: number[]
    r2:
      value: string[]
  frames:
    - frame:
      view:
        component: OTUqiDataProvider
        props:
          source: mysql-demo
          query: >
            SELECT JSON_ARRAY(1, NULL, 3) AS value
          output: [:r1]
      frames:
        - frame:
          view:
            component: DataDemo
            props:
              results: :r1
    - frame:
      view:
        component: OTUqiDataProvider
        props:
          source: mysql-demo
          query: >
            SELECT JSON_ARRAY('one', NULL, 'three') AS value
          output: [:r2]
      frames:
        - frame:
          view:
            component: DataDemo
            props:
              results: :r2
```

## How

This PR
- https://github.com/open-truss/open-truss/pull/183/commits/7cdf5873c3942c80a59ff1e06f48df411cc84f50 Updates the dynamic signals code to do lookups in the pre-existing list of signals. Previously, when you created a signal that wasn't in the predefined list, it would not use that list when defining signals inside of nested types (e.g. object properties). Now you can use predefined signals in nested types.
-  https://github.com/open-truss/open-truss/commit/94919ce621bd767ed8e3250918f1aec8fced2b00 Updated the front-end uqi type casting code to not call JSON.parse when the return value is a JSON type and it is already an array or object. The value has already been parsed and it was throwing an exception trying to parse it again.
- https://github.com/open-truss/open-truss/commit/e1d20bc3f395be001d978a6fb51167e3d8926854 Adds an array type mapping for the trino client so that uqi can process array types from trino.
- https://github.com/open-truss/open-truss/commit/599683875b87488e4560adaf84ea25ba0b70528c Cleans up the dynamic signals code to be more legible and adds support for multi-dimensional arrays.
- https://github.com/open-truss/open-truss/commit/5cb1d2e7271e3e5594347565ce0170560c62e45a Add demo for alternate multi dimensional array syntax 

cc @open-truss/engineers 