### PR TITLE
use object-hash instead of crypto-js for object hashing

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -55,7 +55,7 @@
     },
     "../packages/open-truss": {
       "name": "@open-truss/open-truss",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -59,8 +59,8 @@
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",
-        "crypto-js": "^4.2.0",
         "lodash": "^4.17.21",
+        "object-hash": "^3.0.0",
         "sql-formatter": "^13.0.4",
         "ts-node": "^10.9.1",
         "yaml": "^2.3.4",
@@ -73,6 +73,7 @@
         "@types/crypto-js": "^4.2.2",
         "@types/jest": "^29.5.8",
         "@types/lodash": "^4.14.202",
+        "@types/object-hash": "^3.0.6",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",
-        "crypto-js": "^4.2.0",
         "lodash": "^4.17.21",
+        "object-hash": "^3.0.0",
         "sql-formatter": "^13.0.4",
         "ts-node": "^10.9.1",
         "yaml": "^2.3.4",
@@ -24,6 +24,7 @@
         "@types/crypto-js": "^4.2.2",
         "@types/jest": "^29.5.8",
         "@types/lodash": "^4.14.202",
+        "@types/object-hash": "^3.0.6",
         "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
@@ -1583,6 +1584,12 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/object-hash": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==",
+      "dev": true
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.10",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
@@ -2505,11 +2512,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/csstype": {
       "version": "3.1.2",
@@ -5069,6 +5071,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -7921,6 +7931,12 @@
         "undici-types": "~5.26.4"
       }
     },
+    "@types/object-hash": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/object-hash/-/object-hash-3.0.6.tgz",
+      "integrity": "sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.10",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.10.tgz",
@@ -8570,11 +8586,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "csstype": {
       "version": "3.1.2",
@@ -10491,6 +10502,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
+    },
+    "object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="
     },
     "object-inspect": {
       "version": "1.13.1",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -51,8 +51,8 @@
   "typings": "./dist/mjs/index.d.ts",
   "dependencies": {
     "@preact/signals-react": "^2.0.0",
-    "crypto-js": "^4.2.0",
     "lodash": "^4.17.21",
+    "object-hash": "^3.0.0",
     "sql-formatter": "^13.0.4",
     "ts-node": "^10.9.1",
     "yaml": "^2.3.4",
@@ -62,6 +62,7 @@
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "^29.5.8",
     "@types/lodash": "^4.14.202",
+    "@types/object-hash": "^3.0.6",
     "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/signals/index.tsx
+++ b/packages/open-truss/src/signals/index.tsx
@@ -2,7 +2,7 @@ import { z, type ZodTypeAny } from 'zod'
 import { useSignal, type Signal as PreactSignal } from '@preact/signals-react'
 import { typeToZodMap, typeToDefaultValue } from '../utils/describe-zod'
 import { isObject } from '../utils/misc'
-import CryptoJS from 'crypto-js'
+import hash from 'object-hash'
 
 export interface Signal<T = any | null> extends PreactSignal<T | null> {
   name: string // Used to look up the zodShape for a given signal
@@ -116,8 +116,7 @@ export function createSignal(
 }
 
 function signalNameFromObject(signal: object | object[]): string {
-  const s = JSON.stringify(signal)
-  return CryptoJS.SHA256(s).toString()
+  return hash(signal)
 }
 
 type DefaultValue = object | object[] | string | boolean | number


### PR DESCRIPTION
## Why?

This is kinda a silly one, but I think still good to do. We use `crypto-js` to perform SHA hashing on a signal object, which is used to give each signal a unique name based on its definition. This package [has a non-ASCII character in its source code](https://github.com/brix/crypto-js/blob/ac34a5a584337b33a2e567f50d96819a96ac44bf/src/ripemd160.js#L2), which is not allowed in my project's build 😅 

## How?

To keep this functionality, which I think we should, I imported and used a different package: [`object-hash`](https://github.com/puleos/object-hash). It does less than `crypto-js`, but that's fine as all we need is the hashing capabilities. (I didn't check, but I'd assume the bundle size decreased due to this change :tada:)

### Testing

I used example 6-state-management-demo to ensure signals are still working.

<img width="365" alt="image" src="https://github.com/open-truss/open-truss/assets/3272924/ac4fc515-4a42-4643-a708-f0c96f141ddc">


### Considerations

I considered removing this functionality and instead doing something simpler like appending a counter or the current timestamp. However, it does seem nice to give repeated definitions a pointer to the same signal so I kept it. We can revisit if we want of course.