### PR TITLE
Report percentageComplete

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -56,7 +56,7 @@
     },
     "../packages/open-truss": {
       "name": "@open-truss/open-truss",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/demo-app/src/lib/mysql-uqi-client.ts
+++ b/demo-app/src/lib/mysql-uqi-client.ts
@@ -69,6 +69,7 @@ async function createMysqlUqiClient(config: MysqlConfig): Promise<UqiClient> {
     async function* asyncGenerator(): AsyncGenerator<UqiResult> {
       // Type 'RowDataPacket[] | RowDataPacket[][] | ResultSetHeader'
       if (Array.isArray(rows) && rows.length > 0 && !Array.isArray(rows[0])) {
+        context.status.percentageComplete = Math.floor((context.status.recordsReturned / rows.length) * 100)
         yield {
           row: rows as unknown as UqiScalar[],
           metadata: {
@@ -81,6 +82,7 @@ async function createMysqlUqiClient(config: MysqlConfig): Promise<UqiClient> {
         Array.isArray(rows[0])
       ) {
         for (const row of rows) {
+          context.status.percentageComplete = Math.floor((context.status.recordsReturned / rows.length) * 100)
           yield {
             row: row as unknown as UqiScalar[],
             metadata: {

--- a/demo-app/src/lib/mysql-uqi-client.ts
+++ b/demo-app/src/lib/mysql-uqi-client.ts
@@ -69,7 +69,9 @@ async function createMysqlUqiClient(config: MysqlConfig): Promise<UqiClient> {
     async function* asyncGenerator(): AsyncGenerator<UqiResult> {
       // Type 'RowDataPacket[] | RowDataPacket[][] | ResultSetHeader'
       if (Array.isArray(rows) && rows.length > 0 && !Array.isArray(rows[0])) {
-        context.status.percentageComplete = Math.floor((context.status.recordsReturned / rows.length) * 100)
+        context.status.percentageComplete = Math.floor(
+          (context.status.recordsReturned / rows.length) * 100,
+        )
         yield {
           row: rows as unknown as UqiScalar[],
           metadata: {
@@ -82,7 +84,9 @@ async function createMysqlUqiClient(config: MysqlConfig): Promise<UqiClient> {
         Array.isArray(rows[0])
       ) {
         for (const row of rows) {
-          context.status.percentageComplete = Math.floor((context.status.recordsReturned / rows.length) * 100)
+          context.status.percentageComplete = Math.floor(
+            (context.status.recordsReturned / rows.length) * 100,
+          )
           yield {
             row: row as unknown as UqiScalar[],
             metadata: {

--- a/demo-app/src/lib/trino-uqi-client.ts
+++ b/demo-app/src/lib/trino-uqi-client.ts
@@ -56,6 +56,7 @@ async function createTrinoUqiClient(config: TrinoConfig): Promise<UqiClient> {
             queryResult?.columns?.forEach((column, idx) => {
               row.push(trinoColumnParser(rawRow[idx], column.type))
             })
+            context.status.recordsReturned += 1
 
             yield {
               row,

--- a/demo-app/src/open-truss/configs/9-kusto-demo.yaml
+++ b/demo-app/src/open-truss/configs/9-kusto-demo.yaml
@@ -8,7 +8,7 @@ workflow:
       view:
         component: OTUqiDataProvider
         props:
-        source: kusto-demo
+          source: kusto-demo
           query: cluster("acme").database("widgets").RawEvent | limit 1
           output: [:results]
       frames:

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.23.0",
+  "version": "0.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/uqi/example/fake-client-uqi.test.ts
+++ b/packages/open-truss/src/uqi/example/fake-client-uqi.test.ts
@@ -20,6 +20,7 @@ describe('fake-client-uqi', () => {
       completedAt: null,
       failedAt: null,
       failedReason: '',
+      percentageComplete: 0,
       recordsReturned: 0,
       startedAt: null,
     }
@@ -67,6 +68,7 @@ describe('fake-client-uqi', () => {
       completedAt: null,
       failedAt: null,
       failedReason: '',
+      percentageComplete: 0,
       recordsReturned: 0,
       startedAt: null,
     }

--- a/packages/open-truss/src/uqi/uqi.ts
+++ b/packages/open-truss/src/uqi/uqi.ts
@@ -67,6 +67,7 @@ export interface UqiStatus {
   completedAt: Date | null
   failedAt: Date | null
   failedReason: string | null
+  percentageComplete: number
   recordsReturned: number
   startedAt: Date | null
 }
@@ -79,6 +80,7 @@ export function uqi<C, T>(og: UqiSettings<C, T>): UqiClient {
       completedAt: null,
       failedAt: null,
       failedReason: null,
+      percentageComplete: 0,
       recordsReturned: 0,
       startedAt: null,
     },


### PR DESCRIPTION
🍐 with @jonmagic 

https://github.com/open-truss/open-truss/issues/190

This PR lays some groundwork for reporting the percentage of a query that has completed.  We'd like this to work with Kusto, Trino, and MySQL for Uqi, but haven't been able to find a good metric for Kusto or Trino.  However, this PR adds the `percentageComplete` field that can be used if the data is available.

This also does a quick bugfix for the Kusto demo config to make it valid YAML.

