### PR TITLE
0.25.0 -> 0.26.0, pulling in CVE fixes from #202 and #203

### DIFF
--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
This will get #202 and #203 out for any downstream consumers.