### PR TITLE
Update package version to 0.29.0

### DIFF
--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
### Why

I couldn't pull in the new GraphQL data provider changes which I believe is due to the package version not being updated

### How
 
 Updated the version 🥱 