### PR TITLE
Fix OTUqiDataProvider

### DIFF
--- a/demo-app/package-lock.json
+++ b/demo-app/package-lock.json
@@ -57,7 +57,7 @@
     },
     "../packages/open-truss": {
       "name": "@open-truss/open-truss",
-      "version": "0.29.0",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package-lock.json
+++ b/packages/open-truss/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.28.0",
+  "version": "0.31.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-truss/open-truss",
-      "version": "0.28.0",
+      "version": "0.31.0",
       "license": "MIT",
       "dependencies": {
         "@preact/signals-react": "^2.0.0",

--- a/packages/open-truss/package.json
+++ b/packages/open-truss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-truss/open-truss",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "Framework for building internal tools",
   "directories": {
     "doc": "docs"

--- a/packages/open-truss/src/components/OTUqiDataProvider.tsx
+++ b/packages/open-truss/src/components/OTUqiDataProvider.tsx
@@ -9,7 +9,7 @@ import {
   StringSignal,
   UnknownSignal,
   signalValueShape,
-  useSignals,
+  useSignalEffect,
 } from '../signals'
 import { type UqiMetadata, type UqiNamedFieldsRow } from '../uqi/uqi'
 import { isObject } from '../utils/misc'
@@ -31,53 +31,55 @@ const OTUqiDataProvider: BaseOpenTrussComponentV1<z.infer<typeof Props>> = (
   props,
 ) => {
   const { query, forceQuery, children, output, source, _DEBUG_ } = props
-  useSignals()
 
-  if (_DEBUG_) console.log({ m: 'Query values', query, source })
-  let queryResults: SynchronousUqiQueryResult
-  if (query.value === '') return
-  const fetchData = async function (): Promise<undefined> {
-    const result = await fetch('/api/synchronous-uqi-query', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        // The uqi-force-query header is a hack to make it easy to force a query
-        // that works by including a NumberSignal that can be incremented by the
-        // application which triggers a re-rendering of this component.
-        'uqi-force-query': String(forceQuery?.value),
-      },
-      body: JSON.stringify({ query, source }),
-    })
-    const deserialized = await result.json()
-    if (_DEBUG_) console.log({ m: 'UQI API response', response: deserialized })
-    queryResults = deserialized
-  }
+  useSignalEffect(() => {
+    if (_DEBUG_) console.log({ m: 'Query values', query, source })
+    let queryResults: SynchronousUqiQueryResult
+    if (query.value === '') return
+    const fetchData = async function (): Promise<undefined> {
+      const result = await fetch('/api/synchronous-uqi-query', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // The uqi-force-query header is a hack to make it easy to force a query
+          // that works by including a NumberSignal that can be incremented by the
+          // application which triggers a re-rendering of this component.
+          'uqi-force-query': String(forceQuery?.value),
+        },
+        body: JSON.stringify({ query, source }),
+      })
+      const deserialized = await result.json()
+      if (_DEBUG_)
+        console.log({ m: 'UQI API response', response: deserialized })
+      queryResults = deserialized
+    }
 
-  fetchData()
-    .then(() => {
-      if (queryResults === undefined) return
+    fetchData()
+      .then(() => {
+        if (queryResults === undefined) return
 
-      for (const signal of output || []) {
-        const shape = signalValueShape(signal)
-        const defaultValue = shape.parse(undefined)
+        for (const signal of output || []) {
+          const shape = signalValueShape(signal)
+          const defaultValue = shape.parse(undefined)
 
-        const result = Array.isArray(defaultValue)
-          ? queryResults.rows
-          : isObject(defaultValue)
-          ? queryResults.rows[0]
-          : queryResults.rows[0]?.[signal.yamlName]
+          const result = Array.isArray(defaultValue)
+            ? queryResults.rows
+            : isObject(defaultValue)
+            ? queryResults.rows[0]
+            : queryResults.rows[0]?.[signal.yamlName]
 
-        const validatedResult = shape.parse(result)
-        if (_DEBUG_)
-          console.log({
-            m: 'Parsed UQI results',
-            signal: signal.yamlName,
-            validatedResult,
-          })
-        signal.value = validatedResult
-      }
-    })
-    .catch(console.error)
+          const validatedResult = shape.parse(result)
+          if (_DEBUG_)
+            console.log({
+              m: 'Parsed UQI results',
+              signal: signal.yamlName,
+              validatedResult,
+            })
+          signal.value = validatedResult
+        }
+      })
+      .catch(console.error)
+  })
 
   return children
 }


### PR DESCRIPTION
The changes in https://github.com/open-truss/open-truss/pull/215/files#r1744560877 actually broke OTUqiDataProvider as the asynchronous calls were happening outside a useEffect hook. I returned it to the previous implementation which used `useSignalEffect`.